### PR TITLE
Add HTML templates for international trade documents

### DIFF
--- a/templates/fr/commercial_invoice_template.html
+++ b/templates/fr/commercial_invoice_template.html
@@ -1,0 +1,284 @@
+<!DOCTYPE html>
+<html lang="fr">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Facture Commerciale</title>
+    <style>
+        body {
+            font-family: Arial, sans-serif;
+            margin: 20px;
+            color: #333;
+        }
+        .invoice-container {
+            border: 1px solid #ccc;
+            padding: 20px;
+            max-width: 800px;
+            margin: auto;
+            background: #fff;
+        }
+        .invoice-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: flex-start;
+            margin-bottom: 30px;
+            padding-bottom: 20px;
+            border-bottom: 2px solid #000;
+        }
+        .invoice-header .seller-details,
+        .invoice-header .invoice-details {
+            width: 48%;
+        }
+        .invoice-header h1 {
+            margin: 0;
+            font-size: 2.5em;
+            color: #000;
+        }
+        .invoice-header .logo {
+            max-width: 150px; /* Placeholder for logo */
+            /* {{seller_logo_url}} */
+        }
+        .company-address p, .invoice-info p {
+            margin: 5px 0;
+            font-size: 0.9em;
+        }
+        .buyer-details {
+            margin-bottom: 30px;
+            padding: 15px;
+            border: 1px solid #eee;
+            background-color: #f9f9f9;
+        }
+        .buyer-details h3 {
+            margin-top: 0;
+            font-size: 1.2em;
+            border-bottom: 1px solid #ddd;
+            padding-bottom: 5px;
+        }
+        .items-table {
+            width: 100%;
+            border-collapse: collapse;
+            margin-bottom: 30px;
+        }
+        .items-table th, .items-table td {
+            border: 1px solid #ddd;
+            padding: 10px;
+            text-align: left;
+            font-size: 0.9em;
+        }
+        .items-table th {
+            background-color: #f2f2f2;
+            font-weight: bold;
+        }
+        .items-table td.quantity, .items-table td.unit-price, .items-table td.total-price {
+            text-align: right;
+        }
+        .totals-section {
+            display: flex;
+            justify-content: flex-end;
+            margin-bottom: 30px;
+        }
+        .totals-table {
+            width: 50%;
+            border-collapse: collapse;
+        }
+        .totals-table td {
+            padding: 8px;
+            font-size: 0.95em;
+            border-bottom: 1px solid #eee;
+        }
+        .totals-table td.label {
+            font-weight: bold;
+            text-align: right;
+            padding-right: 15px;
+        }
+        .totals-table td.value {
+            text-align: right;
+        }
+        .totals-table tr.grand-total td {
+            font-weight: bold;
+            font-size: 1.2em;
+            border-top: 2px solid #000;
+        }
+        .terms-section, .bank-details-section, .declaration-section {
+            margin-bottom: 20px;
+            padding: 15px;
+            border: 1px solid #eee;
+        }
+        .terms-section h4, .bank-details-section h4, .declaration-section h4 {
+            margin-top: 0;
+            font-size: 1.1em;
+            border-bottom: 1px solid #ddd;
+            padding-bottom: 5px;
+        }
+        .footer {
+            text-align: center;
+            margin-top: 40px;
+            padding-top: 20px;
+            border-top: 1px solid #ccc;
+            font-size: 0.8em;
+            color: #777;
+        }
+        .signature-area {
+            margin-top: 50px;
+            padding-top: 20px;
+            border-top: 1px dashed #ccc;
+            text-align: right;
+        }
+        .signature-area p {
+            margin-top: 30px;
+        }
+    </style>
+</head>
+<body>
+    <div class="invoice-container">
+        <header class="invoice-header">
+            <div class="seller-details">
+                <!-- Consider adding a logo placeholder if desired -->
+                <!-- <img src="{{seller_logo_url}}" alt="Logo Vendeur" class="logo"> -->
+                <h2>{{seller_name}}</h2>
+                <div class="company-address">
+                    <p>{{seller_address_line1}}</p>
+                    <p>{{seller_address_line2}}</p>
+                    <p>{{seller_city_zip_country}}</p>
+                    <p>Tél: {{seller_phone}}</p>
+                    <p>Email: {{seller_email}}</p>
+                    <p>No TVA: {{seller_vat_number}}</p>
+                </div>
+            </div>
+            <div class="invoice-details" style="text-align: right;">
+                <h1>FACTURE COMMERCIALE</h1>
+                <div class="invoice-info">
+                    <p><strong>Facture N°:</strong> {{invoice_number}}</p>
+                    <p><strong>Date:</strong> {{invoice_date}}</p>
+                    <p><strong>Commande N°:</strong> {{order_number}}</p>
+                    <p><strong>Date d'expédition:</strong> {{shipping_date}}</p>
+                    <p><strong>AWB/BL N°:</strong> {{awb_bl_number}}</p>
+                </div>
+            </div>
+        </header>
+
+        <section class="buyer-details">
+            <h3>Facturé à:</h3>
+            <p><strong>{{buyer_name}}</strong></p>
+            <p>{{buyer_address_line1}}</p>
+            <p>{{buyer_address_line2}}</p>
+            <p>{{buyer_city_zip_country}}</p>
+            <p>Tél: {{buyer_phone}}</p>
+            <p>Email: {{buyer_email}}</p>
+            <p>No TVA: {{buyer_vat_number}}</p>
+        </section>
+
+        <section class="shipping-details" style="margin-bottom: 30px; padding: 15px; border: 1px solid #eee; background-color: #f9f9f9;">
+            <h3>Expédié à (si différent):</h3>
+            <p><strong>{{shipping_name}}</strong></p>
+            <p>{{shipping_address_line1}}</p>
+            <p>{{shipping_address_line2}}</p>
+            <p>{{shipping_city_zip_country}}</p>
+        </section>
+
+        <table class="items-table">
+            <thead>
+                <tr>
+                    <th>Code HS</th>
+                    <th>Description de la Marchandise</th>
+                    <th class="quantity">Quantité</th>
+                    <th class="unit-price">Prix Unitaire ({{currency}})</th>
+                    <th class="total-price">Prix Total ({{currency}})</th>
+                </tr>
+            </thead>
+            <tbody>
+                <!-- Start: Items Loop -->
+                <!-- {{#each items}} -->
+                <tr>
+                    <td>{{item_hs_code}}</td>
+                    <td>{{item_description}}</td>
+                    <td class="quantity">{{item_quantity}}</td>
+                    <td class="unit-price">{{item_unit_price}}</td>
+                    <td class="total-price">{{item_total_price}}</td>
+                </tr>
+                <!-- {{/each}} -->
+                <!-- End: Items Loop -->
+                <!-- Example Row (remove or comment out when using templating engine) -->
+                <tr>
+                    <td>1234.56.78</td>
+                    <td>Exemple de produit A</td>
+                    <td class="quantity">2</td>
+                    <td class="unit-price">150.00</td>
+                    <td class="total-price">300.00</td>
+                </tr>
+                <tr>
+                    <td>9876.54.32</td>
+                    <td>Exemple de service B</td>
+                    <td class="quantity">1</td>
+                    <td class="unit-price">250.00</td>
+                    <td class="total-price">250.00</td>
+                </tr>
+            </tbody>
+        </table>
+
+        <section class="totals-section">
+            <table class="totals-table">
+                <tbody>
+                    <tr>
+                        <td class="label">Sous-total:</td>
+                        <td class="value">{{subtotal_amount}} {{currency}}</td>
+                    </tr>
+                    <tr>
+                        <td class="label">Frais de transport:</td>
+                        <td class="value">{{shipping_cost}} {{currency}}</td>
+                    </tr>
+                    <tr>
+                        <td class="label">Assurance:</td>
+                        <td class="value">{{insurance_cost}} {{currency}}</td>
+                    </tr>
+                    <tr>
+                        <td class="label">Autres Frais ({{other_charges_description}}):</td>
+                        <td class="value">{{other_charges_amount}} {{currency}}</td>
+                    </tr>
+                    <tr class="grand-total">
+                        <td class="label">TOTAL GÉNÉRAL:</td>
+                        <td class="value">{{grand_total_amount}} {{currency}}</td>
+                    </tr>
+                </tbody>
+            </table>
+        </section>
+
+        <section class="terms-section">
+            <h4>Termes et Conditions:</h4>
+            <p><strong>Termes de vente (Incoterms® 2020):</strong> {{incoterms}}</p>
+            <p><strong>Termes de paiement:</strong> {{payment_terms}}</p>
+            <p><strong>Pays d'origine des marchandises:</strong> {{country_of_origin}}</p>
+            <p><strong>Monnaie de la transaction:</strong> {{currency}}</p>
+        </section>
+
+        <section class="bank-details-section">
+            <h4>Coordonnées Bancaires pour Paiement:</h4>
+            <p><strong>Nom de la banque:</strong> {{bank_name}}</p>
+            <p><strong>Adresse de la banque:</strong> {{bank_address}}</p>
+            <p><strong>Titulaire du compte:</strong> {{bank_account_holder_name}}</p>
+            <p><strong>Numéro de compte (IBAN):</strong> {{bank_iban}}</p>
+            <p><strong>Code SWIFT/BIC:</strong> {{bank_swift_bic}}</p>
+            <p><strong>Référence de paiement:</strong> Facture N° {{invoice_number}}</p>
+        </section>
+
+        <section class="declaration-section">
+            <h4>Déclaration:</h4>
+            <p>{{declaration_statement}}</p>
+            <!-- Example: "Nous certifions que les marchandises désignées ci-dessus sont conformes aux indications de cette facture et que, sauf indication contraire, leur origine est de {{country_of_origin}}." -->
+        </section>
+
+        <div class="signature-area">
+            <p>_________________________</p>
+            <p>Signature Autorisée / Cachet de l'entreprise</p>
+            <p><strong>{{authorized_signature_name}}</strong></p>
+            <p><em>{{authorized_signature_title}}</em></p>
+        </div>
+
+        <footer class="footer">
+            <p>{{footer_notes}}</p>
+            <!-- Example: "Merci pour votre confiance." -->
+            <p>&copy; {{current_year}} {{seller_name}}. Tous droits réservés.</p>
+        </footer>
+    </div>
+</body>
+</html>

--- a/templates/fr/packing_list_template.html
+++ b/templates/fr/packing_list_template.html
@@ -1,0 +1,280 @@
+<!DOCTYPE html>
+<html lang="fr">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Liste de Colisage</title>
+    <style>
+        body {
+            font-family: Arial, sans-serif;
+            margin: 20px;
+            color: #333;
+        }
+        .packing-list-container {
+            border: 1px solid #ccc;
+            padding: 20px;
+            max-width: 800px; /* Adjusted for potentially wider tables */
+            margin: auto;
+            background: #fff;
+        }
+        .header-section {
+            display: flex;
+            justify-content: space-between;
+            align-items: flex-start;
+            margin-bottom: 20px;
+            padding-bottom: 20px;
+            border-bottom: 2px solid #000;
+        }
+        .header-section .company-details,
+        .header-section .document-details {
+            width: 48%;
+        }
+        .header-section h1 {
+            margin: 0 0 10px 0;
+            font-size: 2.2em;
+            color: #000;
+        }
+        .company-address p, .document-info p {
+            margin: 4px 0;
+            font-size: 0.9em;
+        }
+        .parties-section {
+            display: flex;
+            justify-content: space-between;
+            margin-bottom: 20px;
+        }
+        .parties-section .shipper-details,
+        .parties-section .consignee-details,
+        .parties-section .notify-party-details {
+            width: 32%; /* Adjust if notify party is not always present */
+            padding: 10px;
+            border: 1px solid #eee;
+            background-color: #f9f9f9;
+            font-size: 0.85em;
+        }
+        .parties-section h4 {
+            margin-top: 0;
+            font-size: 1.1em;
+            border-bottom: 1px solid #ddd;
+            padding-bottom: 5px;
+        }
+        .shipment-info-section {
+            margin-bottom: 20px;
+            padding: 10px;
+            border: 1px solid #eee;
+        }
+        .shipment-info-section h4 {
+             margin-top: 0;
+            font-size: 1.1em;
+            border-bottom: 1px solid #ddd;
+            padding-bottom: 5px;
+        }
+        .shipment-info-section p {
+            margin: 5px 0;
+            font-size: 0.9em;
+        }
+        .packages-table {
+            width: 100%;
+            border-collapse: collapse;
+            margin-bottom: 20px;
+        }
+        .packages-table th, .packages-table td {
+            border: 1px solid #ddd;
+            padding: 8px;
+            text-align: left;
+            font-size: 0.85em;
+        }
+        .packages-table th {
+            background-color: #f2f2f2;
+            font-weight: bold;
+        }
+        .packages-table td.number-column { /* For numeric values like quantity, weights, dimensions */
+            text-align: right;
+        }
+        .totals-summary-table {
+            width: 100%;
+            border-collapse: collapse;
+            margin-bottom: 20px;
+        }
+        .totals-summary-table th, .totals-summary-table td {
+            border: 1px solid #ddd;
+            padding: 8px;
+            font-size: 0.9em;
+            text-align: right;
+            font-weight: bold;
+        }
+        .totals-summary-table th {
+            text-align: left;
+            background-color: #f2f2f2;
+        }
+        .footer {
+            text-align: center;
+            margin-top: 30px;
+            padding-top: 15px;
+            border-top: 1px solid #ccc;
+            font-size: 0.8em;
+            color: #777;
+        }
+        .signature-area {
+            margin-top: 40px;
+            padding-top: 20px;
+            border-top: 1px dashed #ccc;
+            text-align: right;
+        }
+        .signature-area p {
+            margin-top: 25px;
+        }
+    </style>
+</head>
+<body>
+    <div class="packing-list-container">
+        <header class="header-section">
+            <div class="company-details">
+                <h2>{{shipper_name}}</h2>
+                <div class="company-address">
+                    <p>{{shipper_address_line1}}</p>
+                    <p>{{shipper_address_line2}}</p>
+                    <p>{{shipper_city_zip_country}}</p>
+                    <p>Tél: {{shipper_phone}}</p>
+                </div>
+            </div>
+            <div class="document-details" style="text-align: right;">
+                <h1>LISTE DE COLISAGE</h1>
+                <div class="document-info">
+                    <p><strong>Liste de Colisage N°:</strong> {{packing_list_number}}</p>
+                    <p><strong>Date:</strong> {{packing_list_date}}</p>
+                    <p><strong>Facture Commerciale N°:</strong> {{invoice_number}}</p>
+                    <p><strong>Commande N°:</strong> {{order_number}}</p>
+                </div>
+            </div>
+        </header>
+
+        <section class="parties-section">
+            <div class="shipper-details">
+                <h4>Expéditeur:</h4>
+                <p><strong>{{shipper_name}}</strong></p>
+                <p>{{shipper_address_line1}}</p>
+                <p>{{shipper_address_line2}}</p>
+                <p>{{shipper_city_zip_country}}</p>
+                <p>Contact: {{shipper_contact_person}}</p>
+            </div>
+            <div class="consignee-details">
+                <h4>Destinataire:</h4>
+                <p><strong>{{consignee_name}}</strong></p>
+                <p>{{consignee_address_line1}}</p>
+                <p>{{consignee_address_line2}}</p>
+                <p>{{consignee_city_zip_country}}</p>
+                <p>Contact: {{consignee_contact_person}}</p>
+            </div>
+            <div class="notify-party-details">
+                <h4>Notifier (si applicable):</h4>
+                <p><strong>{{notify_party_name}}</strong></p>
+                <p>{{notify_party_address_line1}}</p>
+                <p>{{notify_party_address_line2}}</p>
+                <p>{{notify_party_city_zip_country}}</p>
+            </div>
+        </section>
+
+        <section class="shipment-info-section">
+            <h4>Informations sur l'Expédition:</h4>
+            <p><strong>Date d'expédition:</strong> {{shipping_date}}</p>
+            <p><strong>Mode de Transport:</strong> {{mode_of_transport}}</p>
+            <p><strong>Navire/Vol N°:</strong> {{vessel_flight_number}}</p>
+            <p><strong>Port de Chargement:</strong> {{port_of_loading}}</p>
+            <p><strong>Port de Déchargement:</strong> {{port_of_discharge}}</p>
+            <p><strong>Destination Finale:</strong> {{final_destination}}</p>
+        </section>
+
+        <table class="packages-table">
+            <thead>
+                <tr>
+                    <th>Colis N°</th>
+                    <th>Marques et Numéros</th>
+                    <th>Description des Marchandises</th>
+                    <th class="number-column">Quantité</th>
+                    <th class="number-column">Poids Net ({{weight_unit}})</th>
+                    <th class="number-column">Poids Brut ({{weight_unit}})</th>
+                    <th>Dimensions (LxlxH {{dimension_unit}})</th>
+                    <th class="number-column">Volume ({{volume_unit}})</th>
+                </tr>
+            </thead>
+            <tbody>
+                <!-- Start: Packages Loop -->
+                <!-- {{#each packages}} -->
+                <tr>
+                    <td>{{package_number_identifier}}</td> <!-- e.g., "1 sur N" or specific ID -->
+                    <td>{{package_marks_and_numbers}}</td>
+                    <td>{{package_goods_description}}</td>
+                    <td class="number-column">{{package_quantity}}</td>
+                    <td class="number-column">{{package_net_weight}}</td>
+                    <td class="number-column">{{package_gross_weight}}</td>
+                    <td>{{package_dimensions}}</td>
+                    <td class="number-column">{{package_volume}}</td>
+                </tr>
+                <!-- {{/each}} -->
+                <!-- Example Row (remove or comment out) -->
+                <tr>
+                    <td>1/2</td>
+                    <td>ORDER #123<br>CTN 1<br>MADE IN FR</td>
+                    <td>Pièces détachées Modèle X (Vis, Boulons, Écrous assortis)</td>
+                    <td class="number-column">1 CARTON</td>
+                    <td class="number-column">10.50</td>
+                    <td class="number-column">11.20</td>
+                    <td>60x40x30 cm</td>
+                    <td class="number-column">0.072</td>
+                </tr>
+                <tr>
+                    <td>2/2</td>
+                    <td>ORDER #123<br>CTN 2<br>MADE IN FR</td>
+                    <td>Unité principale Modèle Y (assemblée)</td>
+                    <td class="number-column">1 CAISSE</td>
+                    <td class="number-column">75.00</td>
+                    <td class="number-column">82.50</td>
+                    <td>120x80x100 cm</td>
+                    <td class="number-column">0.960</td>
+                </tr>
+            </tbody>
+        </table>
+
+        <table class="totals-summary-table">
+            <thead>
+                <tr>
+                    <th colspan="4">Récapitulatif Total:</th>
+                </tr>
+            </thead>
+            <tbody>
+                <tr>
+                    <td><strong>Nombre Total de Colis:</strong></td>
+                    <td>{{total_packages_quantity}}</td>
+                    <td><strong>Poids Net Total:</strong></td>
+                    <td>{{total_net_weight}} {{weight_unit}}</td>
+                </tr>
+                <tr>
+                    <td><strong>Volume Total:</strong></td>
+                    <td>{{total_volume}} {{volume_unit}}</td>
+                    <td><strong>Poids Brut Total:</strong></td>
+                    <td>{{total_gross_weight}} {{weight_unit}}</td>
+                </tr>
+            </tbody>
+        </table>
+
+        <section class="remarks-section" style="margin-top: 20px; padding: 10px; border: 1px solid #eee; font-size:0.9em;">
+            <h4>Remarques:</h4>
+            <p>{{remarks}}</p>
+            <!-- Example: "Contenu fragile. Manipuler avec soin." -->
+        </section>
+
+        <div class="signature-area">
+            <p>_________________________</p>
+            <p>Signature Autorisée / Cachet de l'entreprise</p>
+            <p><strong>{{authorized_signature_name}}</strong></p>
+            <p><em>{{authorized_signature_title}}</em></p>
+        </div>
+
+        <footer class="footer">
+            <p>{{footer_notes}}</p>
+            <p>&copy; {{current_year}} {{shipper_name}}.</p>
+        </footer>
+    </div>
+</body>
+</html>

--- a/templates/fr/proforma_invoice_template.html
+++ b/templates/fr/proforma_invoice_template.html
@@ -1,0 +1,266 @@
+<!DOCTYPE html>
+<html lang="fr">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Facture Proforma</title>
+    <style>
+        body {
+            font-family: Arial, sans-serif;
+            margin: 20px;
+            color: #333;
+        }
+        .invoice-container {
+            border: 1px solid #ccc;
+            padding: 20px;
+            max-width: 800px;
+            margin: auto;
+            background: #fff;
+        }
+        .invoice-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: flex-start;
+            margin-bottom: 30px;
+            padding-bottom: 20px;
+            border-bottom: 2px solid #000;
+        }
+        .invoice-header .seller-details,
+        .invoice-header .invoice-details {
+            width: 48%;
+        }
+        .invoice-header h1 {
+            margin: 0;
+            font-size: 2.5em;
+            color: #000;
+        }
+        .invoice-header .logo {
+            max-width: 150px; /* Placeholder for logo */
+            /* {{seller_logo_url}} */
+        }
+        .company-address p, .invoice-info p {
+            margin: 5px 0;
+            font-size: 0.9em;
+        }
+        .buyer-details {
+            margin-bottom: 30px;
+            padding: 15px;
+            border: 1px solid #eee;
+            background-color: #f9f9f9;
+        }
+        .buyer-details h3 {
+            margin-top: 0;
+            font-size: 1.2em;
+            border-bottom: 1px solid #ddd;
+            padding-bottom: 5px;
+        }
+        .items-table {
+            width: 100%;
+            border-collapse: collapse;
+            margin-bottom: 30px;
+        }
+        .items-table th, .items-table td {
+            border: 1px solid #ddd;
+            padding: 10px;
+            text-align: left;
+            font-size: 0.9em;
+        }
+        .items-table th {
+            background-color: #f2f2f2;
+            font-weight: bold;
+        }
+        .items-table td.quantity, .items-table td.unit-price, .items-table td.total-price {
+            text-align: right;
+        }
+        .totals-section {
+            display: flex;
+            justify-content: flex-end;
+            margin-bottom: 30px;
+        }
+        .totals-table {
+            width: 50%;
+            border-collapse: collapse;
+        }
+        .totals-table td {
+            padding: 8px;
+            font-size: 0.95em;
+            border-bottom: 1px solid #eee;
+        }
+        .totals-table td.label {
+            font-weight: bold;
+            text-align: right;
+            padding-right: 15px;
+        }
+        .totals-table td.value {
+            text-align: right;
+        }
+        .totals-table tr.grand-total td {
+            font-weight: bold;
+            font-size: 1.2em;
+            border-top: 2px solid #000;
+        }
+        .terms-section, .bank-details-section, .validity-section {
+            margin-bottom: 20px;
+            padding: 15px;
+            border: 1px solid #eee;
+        }
+        .terms-section h4, .bank-details-section h4, .validity-section h4 {
+            margin-top: 0;
+            font-size: 1.1em;
+            border-bottom: 1px solid #ddd;
+            padding-bottom: 5px;
+        }
+        .footer {
+            text-align: center;
+            margin-top: 40px;
+            padding-top: 20px;
+            border-top: 1px solid #ccc;
+            font-size: 0.8em;
+            color: #777;
+        }
+        .signature-area {
+            margin-top: 50px;
+            padding-top: 20px;
+            border-top: 1px dashed #ccc;
+            text-align: right;
+        }
+        .signature-area p {
+            margin-top: 30px;
+        }
+    </style>
+</head>
+<body>
+    <div class="invoice-container">
+        <header class="invoice-header">
+            <div class="seller-details">
+                <!-- <img src="{{seller_logo_url}}" alt="Logo Vendeur" class="logo"> -->
+                <h2>{{seller_name}}</h2>
+                <div class="company-address">
+                    <p>{{seller_address_line1}}</p>
+                    <p>{{seller_address_line2}}</p>
+                    <p>{{seller_city_zip_country}}</p>
+                    <p>Tél: {{seller_phone}}</p>
+                    <p>Email: {{seller_email}}</p>
+                    <p>No TVA: {{seller_vat_number}}</p>
+                </div>
+            </div>
+            <div class="invoice-details" style="text-align: right;">
+                <h1>FACTURE PROFORMA</h1>
+                <div class="invoice-info">
+                    <p><strong>Proforma N°:</strong> {{proforma_number}}</p>
+                    <p><strong>Date:</strong> {{proforma_date}}</p>
+                    <p><strong>Référence Client:</strong> {{buyer_reference}}</p>
+                </div>
+            </div>
+        </header>
+
+        <section class="buyer-details">
+            <h3>Client:</h3>
+            <p><strong>{{buyer_name}}</strong></p>
+            <p>{{buyer_address_line1}}</p>
+            <p>{{buyer_address_line2}}</p>
+            <p>{{buyer_city_zip_country}}</p>
+            <p>Tél: {{buyer_phone}}</p>
+            <p>Email: {{buyer_email}}</p>
+        </section>
+
+        <table class="items-table">
+            <thead>
+                <tr>
+                    <th>Description de la Marchandise / Service</th>
+                    <th class="quantity">Quantité</th>
+                    <th class="unit-price">Prix Unitaire Estimé ({{currency}})</th>
+                    <th class="total-price">Prix Total Estimé ({{currency}})</th>
+                </tr>
+            </thead>
+            <tbody>
+                <!-- Start: Items Loop -->
+                <!-- {{#each items}} -->
+                <tr>
+                    <td>{{item_description}}</td>
+                    <td class="quantity">{{item_quantity}}</td>
+                    <td class="unit-price">{{item_unit_price}}</td>
+                    <td class="total-price">{{item_total_price}}</td>
+                </tr>
+                <!-- {{/each}} -->
+                <!-- Example Row (remove or comment out when using templating engine) -->
+                <tr>
+                    <td>Produit Alpha (estimation)</td>
+                    <td class="quantity">5</td>
+                    <td class="unit-price">99.00</td>
+                    <td class="total-price">495.00</td>
+                </tr>
+                <tr>
+                    <td>Service Beta (consultation préliminaire)</td>
+                    <td class="quantity">1</td>
+                    <td class="unit-price">300.00</td>
+                    <td class="total-price">300.00</td>
+                </tr>
+            </tbody>
+        </table>
+
+        <section class="totals-section">
+            <table class="totals-table">
+                <tbody>
+                    <tr>
+                        <td class="label">Sous-total Estimé:</td>
+                        <td class="value">{{subtotal_amount}} {{currency}}</td>
+                    </tr>
+                    <tr>
+                        <td class="label">Frais de transport Estimés:</td>
+                        <td class="value">{{shipping_cost}} {{currency}}</td>
+                    </tr>
+                    <tr>
+                        <td class="label">Assurance Estimée:</td>
+                        <td class="value">{{insurance_cost}} {{currency}}</td>
+                    </tr>
+                    <tr>
+                        <td class="label">Autres Frais Estimés ({{other_charges_description}}):</td>
+                        <td class="value">{{other_charges_amount}} {{currency}}</td>
+                    </tr>
+                    <tr class="grand-total">
+                        <td class="label">TOTAL GÉNÉRAL ESTIMÉ:</td>
+                        <td class="value">{{grand_total_amount}} {{currency}}</td>
+                    </tr>
+                </tbody>
+            </table>
+        </section>
+
+        <section class="terms-section">
+            <h4>Termes et Conditions Provisoires:</h4>
+            <p><strong>Termes de vente (Incoterms® 2020):</strong> {{incoterms}}</p>
+            <p><strong>Termes de paiement:</strong> {{payment_terms}}</p>
+            <p><strong>Date d'expédition estimée:</strong> {{estimated_shipping_date}}</p>
+            <p><strong>Monnaie de la transaction:</strong> {{currency}}</p>
+        </section>
+
+        <section class="bank-details-section">
+            <h4>Coordonnées Bancaires pour Paiement (si applicable pour acompte):</h4>
+            <p><strong>Nom de la banque:</strong> {{bank_name}}</p>
+            <p><strong>Adresse de la banque:</strong> {{bank_address}}</p>
+            <p><strong>Titulaire du compte:</strong> {{bank_account_holder_name}}</p>
+            <p><strong>Numéro de compte (IBAN):</strong> {{bank_iban}}</p>
+            <p><strong>Code SWIFT/BIC:</strong> {{bank_swift_bic}}</p>
+        </section>
+
+        <section class="validity-section">
+            <h4>Validité de l'Offre Proforma:</h4>
+            <p>Cette offre proforma est valide jusqu'au: <strong>{{proforma_validity_date}}</strong>.</p>
+            <p>Les prix sont sujets à confirmation au moment de la commande ferme.</p>
+        </section>
+
+        <div class="signature-area">
+            <p>_________________________</p>
+            <p>Signature Autorisée / Cachet de l'entreprise</p>
+            <p><strong>{{authorized_signature_name}}</strong></p>
+            <p><em>{{authorized_signature_title}}</em></p>
+        </div>
+
+        <footer class="footer">
+            <p>{{footer_notes}}</p>
+            <!-- Example: "Cette facture proforma ne constitue pas un engagement ferme de vente." -->
+            <p>&copy; {{current_year}} {{seller_name}}. Document non contractuel.</p>
+        </footer>
+    </div>
+</body>
+</html>


### PR DESCRIPTION
This commit introduces three new HTML templates for common international trade documents:
- Commercial Invoice
- Proforma Invoice
- Packing List

The templates are located in the `templates/fr/` directory and are named:
- `commercial_invoice_template.html`
- `proforma_invoice_template.html`
- `packing_list_template.html`

Key features of these templates:
- Structured using semantic HTML.
- Include comprehensive placeholders (e.g., `{{seller_name}}`, `{{item_description}}`) for dynamic data insertion.
- Basic inline CSS is provided for a professional look and feel, which can be further customized.
- Localized in French, including titles, headers, and example content.
- Contain comments to guide integration with templating engines (e.g., for loops over items or packages).

These templates are designed to be easily adaptable for integration into an application to generate these essential trade documents.