### PR TITLE
Fix: Resolve ImportError for populate_html in pagedegrde.py

### DIFF
--- a/pagedegrde.py
+++ b/pagedegrde.py
@@ -45,7 +45,7 @@ from reportlab.graphics.shapes import Line, Drawing
 from reportlab.graphics.barcode import code128, qr
 from reportlab.graphics import renderPDF
 import io # Added for io.BytesIO
-from html_to_pdf_util import populate_html, convert_html_to_pdf, WeasyPrintError # Added
+from html_to_pdf_util import render_html_template, convert_html_to_pdf, WeasyPrintError # Added
 
 # Define APP_ROOT_DIR for font path resolution
 if getattr(sys, 'frozen', False) and hasattr(sys, '_MEIPASS'):
@@ -1936,7 +1936,7 @@ class CoverPageGenerator(QMainWindow):
                 else:
                     pdf_config['LOGO_PATH'] = ""
 
-                populated_html = populate_html(template_content, pdf_config)
+                populated_html = render_html_template(template_content, pdf_config)
                 pdf_bytes = convert_html_to_pdf(populated_html, base_url=base_url)
 
                 if pdf_config.get('LOGO_PATH', '').startswith('file://') and "temp_logo_for_html" in pdf_config['LOGO_PATH']:


### PR DESCRIPTION
The `pagedegrde.py` module was attempting to import `populate_html` from `html_to_pdf_util.py`. However, `populate_html` was commented out in `html_to_pdf_util.py` and replaced by a more advanced function, `render_html_template`.

This commit updates `pagedegrde.py` to:
1. Import `render_html_template` instead of `populate_html`.
2. Call `render_html_template` where `populate_html` was previously used within the `generate_pdf_to_buffer` method.

This resolves the `ImportError: cannot import name 'populate_html'` and ensures the application uses the correct, available HTML templating function.