### PR TITLE
Fix: Pass default company ID to populate_html_content

### DIFF
--- a/main.py
+++ b/main.py
@@ -4,6 +4,7 @@ import os
 import json
 # import sqlite3 # Replaced by db_manager
 import db as db_manager
+from db import get_default_company # Added for fetching default company
 from db import DATABASE_NAME as CENTRAL_DATABASE_NAME
 import pandas as pd
 import shutil
@@ -791,7 +792,16 @@ class CreateDocumentDialog(QDialog):
                     try:
                         with open(target_path, 'r', encoding='utf-8') as f:
                             template_content = f.read()
-                        populated_content = HtmlEditor.populate_html_content(template_content, self.client_info)
+
+                        # Fetch default company ID for HTML population
+                        default_company_obj = db_manager.get_default_company()
+                        default_company_id = default_company_obj['company_id'] if default_company_obj else None
+
+                        if default_company_id is None:
+                            QMessageBox.information(self, self.tr("Avertissement"), self.tr("Aucune société par défaut n'est définie. Les détails du vendeur peuvent être manquants dans les documents HTML."))
+
+                        populated_content = HtmlEditor.populate_html_content(template_content, self.client_info, default_company_id)
+
                         with open(target_path, 'w', encoding='utf-8') as f:
                             f.write(populated_content)
                         print(f"Populated HTML: {target_path}")


### PR DESCRIPTION
Addresses an error where `HtmlEditor.populate_html_content` was called without the required `default_company_id_static` argument.

The `CreateDocumentDialog.create_documents` method in `main.py` has been updated to:
1. Fetch the default company from the database using `db_manager.get_default_company()`.
2. Extract the `company_id`.
3. Pass this `company_id` to `HtmlEditor.populate_html_content`.

A warning message is now displayed to you during document creation if no default company is set in the application, advising that seller-related template placeholders may not populate correctly.

This change ensures that seller details from the default company can be correctly used in HTML template generation.