### PR TITLE
Integrate TinyMCE for WYSIWYG HTML Editing

### DIFF
--- a/db.py
+++ b/db.py
@@ -2554,7 +2554,8 @@ def add_product(product_data: dict) -> int | None:
         """
         params = (
             product_data.get('product_name'), product_data.get('description'),
-            product_data.get('category'), product_data.get('base_unit_price'),
+            product_data.get('category'),
+            product_data.get('base_unit_price') if product_data.get('base_unit_price') is not None else 0.0,
             product_data.get('unit_of_measure'), product_data.get('is_active', True),
             now, now
         )
@@ -2699,6 +2700,32 @@ def get_products_by_name_pattern(pattern: str) -> list[dict] | None:
         if conn:
             conn.close()
 
+def get_all_products_for_selection() -> list[dict]:
+    """
+    Retrieves active products (product_id, product_name, description, base_unit_price)
+    for selection, ordered by product_name.
+    """
+    conn = None
+    try:
+        conn = get_db_connection()
+        cursor = conn.cursor()
+        # Filter by is_active = TRUE (or 1 for boolean in SQLite)
+        sql = """
+            SELECT product_id, product_name, description, base_unit_price
+            FROM Products
+            WHERE is_active = TRUE
+            ORDER BY product_name
+        """
+        cursor.execute(sql)
+        rows = cursor.fetchall()
+        return [dict(row) for row in rows]
+    except sqlite3.Error as e:
+        print(f"Database error in get_all_products_for_selection: {e}")
+        return []
+    finally:
+        if conn:
+            conn.close()
+
 # Functions for ClientProjectProducts association
 def add_product_to_client_or_project(link_data: dict) -> int | None:
     """Links a product to a client or project, calculating total price."""
@@ -2706,6 +2733,9 @@ def add_product_to_client_or_project(link_data: dict) -> int | None:
     try:
         conn = get_db_connection()
         cursor = conn.cursor()
+        # Initialize effective_unit_price in case of early exit or error before its definition
+        effective_unit_price = None # Ensure it's in scope for the except block
+        product_info = None # Ensure it's in scope for the except block
 
         product_id = link_data.get('product_id')
         product_info = get_product_by_id(product_id) # Need this for base price
@@ -2714,8 +2744,18 @@ def add_product_to_client_or_project(link_data: dict) -> int | None:
             return None
 
         quantity = link_data.get('quantity', 1)
-        unit_price = link_data.get('unit_price_override', product_info['base_unit_price'])
-        total_price_calculated = quantity * unit_price
+        unit_price_override = link_data.get('unit_price_override')
+
+        if unit_price_override is not None: # Explicit check for None
+            effective_unit_price = unit_price_override
+        else:
+            effective_unit_price = product_info.get('base_unit_price')
+
+        if effective_unit_price is None:
+            print(f"Warning: `effective_unit_price` was None for product ID {product_id} (Quantity: {quantity}, Override: {unit_price_override}, Base from DB: {product_info.get('base_unit_price') if product_info else 'N/A'}). Defaulting to 0.0 to prevent TypeError.")
+            effective_unit_price = 0.0
+
+        total_price_calculated = quantity * effective_unit_price
 
         sql = """
             INSERT INTO ClientProjectProducts (
@@ -2734,6 +2774,17 @@ def add_product_to_client_or_project(link_data: dict) -> int | None:
         cursor.execute(sql, params)
         conn.commit()
         return cursor.lastrowid
+    except TypeError as te: # Specifically catch the error we are investigating
+        print(f"TypeError in add_product_to_client_or_project: {te}")
+        print(f"  product_id: {link_data.get('product_id')}")
+        print(f"  quantity: {link_data.get('quantity', 1)}")
+        print(f"  unit_price_override from link_data: {link_data.get('unit_price_override')}")
+        if product_info: # product_info might be None if error happened before it was fetched
+            print(f"  base_unit_price from product_info: {product_info.get('base_unit_price')}")
+        else:
+            print(f"  product_info was None or not fetched prior to error.")
+        print(f"  effective_unit_price at point of error: {effective_unit_price if 'effective_unit_price' in locals() else 'Not yet defined or error before definition'}")
+        return None # Indicate failure
     except sqlite3.Error as e:
         print(f"Database error in add_product_to_client_or_project: {e}")
         return None

--- a/html_editor_assets/tinymce_loader.html
+++ b/html_editor_assets/tinymce_loader.html
@@ -1,0 +1,74 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="UTF-8">
+    <title>TinyMCE Loader</title>
+    <!-- This path assumes 'tinymce' folder is a sibling to this HTML file -->
+    <script src="tinymce/tinymce.min.js" referrerpolicy="origin"></script>
+    <script type="text/javascript" src="qrc:///qtwebchannel/qwebchannel.js"></script>
+    <style>
+        body, html { margin: 0; padding: 0; height: 100%; overflow: hidden; }
+        /* The #tinymce-editor div will be targeted by TinyMCE */
+    </style>
+    <script>
+        document.addEventListener("DOMContentLoaded", function () {
+            new QWebChannel(qt.webChannelTransport, function (channel) {
+                window.qt_bridge = channel.objects.qt_bridge;
+
+                tinymce.init({
+                    selector: '#tinymce-editor',
+                    inline: false, // Use iframe editor
+                    plugins: 'code table lists link image preview fullscreen help wordcount anchor searchreplace visualblocks charmap insertdatetime media pagebreak', // Added pagebreak
+                    toolbar: 'undo redo | styleselect | bold italic underline | ' +
+                             'alignleft aligncenter alignright alignjustify | ' +
+                             'bullist numlist outdent indent | link image media | ' +
+                             'table | code preview fullscreen help | pagebreak', // Added pagebreak
+                    height: "100%", // Make the editor fill its container
+                    resize: false, // Optional: disable resizing by the user
+                    license_key: 'gpl', // Or your commercial key
+                    setup: function(editor) {
+                        editor.on('init', function() {
+                            console.log("TinyMCE editor instance initialized.");
+                            if (window.qt_bridge) {
+                                console.log("qt_bridge found, emitting onTinymceInitialized.");
+                                window.qt_bridge.onTinymceInitialized();
+                            } else {
+                                console.error("qt_bridge not found on TinyMCE init.");
+                            }
+                        });
+                        // Optional: Listen for content changes to enable save button etc.
+                        // editor.on('Change', function(e) {
+                        //     if(window.qt_bridge) {
+                        //          window.qt_bridge.receiveHtmlContent(editor.getContent());
+                        //     }
+                        // });
+                    }
+                });
+            });
+        });
+
+        function setEditorContent(htmlContent) {
+            const editor = tinymce.get('tinymce-editor');
+            if (editor) {
+                editor.setContent(htmlContent);
+                return true;
+            }
+            console.error("TinyMCE editor instance not found for setEditorContent.");
+            return false;
+        }
+
+        function getEditorContent() {
+            const editor = tinymce.get('tinymce-editor');
+            if (editor) {
+                return editor.getContent();
+            }
+            console.error("TinyMCE editor instance not found for getEditorContent.");
+            return "";
+        }
+    </script>
+</head>
+<body>
+    <!-- This div will be replaced by TinyMCE -->
+    <div id="tinymce-editor" style="width: 100%; height: 100vh;"></div>
+</body>
+</html>

--- a/main.py
+++ b/main.py
@@ -39,6 +39,7 @@ from docx import Document # Added for .docx support
 from company_management import CompanyTabWidget # Added for Company Management
 from datetime import datetime # Ensure datetime is explicitly imported if not already for populate_docx_template
 from projectManagement import MainDashboard as ProjectManagementDashboard # Added for integration
+from html_to_pdf_util import convert_html_to_pdf # For PDF generation from HTML
 
 import sqlite3
 
@@ -682,9 +683,68 @@ class ProductDialog(QDialog):
         self.client_id = client_id
         # self.product_data = product_data or {} # Original single product data, not used for multi-line
         self.setWindowTitle(self.tr("Ajouter Produits au Client")) # Title for multi-line
-        self.setMinimumSize(700, 600) # Adjusted for table and new layout
+        self.setMinimumSize(700, 750) # Adjusted for table and new layout (increased height for search)
         # Refactor: Multi-line product entry
         self.setup_ui()
+        self._load_existing_products() # Call to load products initially
+
+    def _load_existing_products(self):
+        self.existing_products_list.clear()
+        try:
+            products = db_manager.get_all_products_for_selection() # This function was added in a previous step
+            if products is None: products = [] # Ensure products is iterable
+
+            for product_data in products:
+                # product_id = product_data.get('product_id')
+                product_name = product_data.get('product_name', 'N/A')
+                description = product_data.get('description', '')
+                base_unit_price = product_data.get('base_unit_price', 0.0)
+
+                # Create a more informative display string
+                desc_snippet = (description[:30] + '...') if len(description) > 30 else description
+                display_text = f"{product_name} (Desc: {desc_snippet}, Prix: {base_unit_price:.2f} €)"
+
+                item = QListWidgetItem(display_text)
+                item.setData(Qt.UserRole, product_data) # Store the whole dictionary
+                self.existing_products_list.addItem(item)
+        except Exception as e:
+            print(f"Error loading existing products: {e}")
+            # Optionally, show a message to the user
+            QMessageBox.warning(self, self.tr("Erreur Chargement Produits"),
+                                self.tr("Impossible de charger la liste des produits existants:\n{0}").format(str(e)))
+
+    def _filter_existing_products_list(self):
+        search_text = self.search_existing_product_input.text().lower()
+        for i in range(self.existing_products_list.count()):
+            item = self.existing_products_list.item(i)
+            product_data = item.data(Qt.UserRole)
+            if product_data: # Check if data exists
+                item_text = product_data.get('product_name', '').lower()
+                item_description = product_data.get('description', '').lower()
+                # Make search more comprehensive by checking name and description
+                if search_text in item_text or search_text in item_description:
+                    item.setHidden(False)
+                else:
+                    item.setHidden(True)
+            else: # If no data, hide by default or handle as error
+                item.setHidden(True)
+
+    def _populate_form_from_selected_product(self, item):
+        product_data = item.data(Qt.UserRole)
+        if product_data:
+            self.name_input.setText(product_data.get('product_name', ''))
+            self.description_input.setPlainText(product_data.get('description', ''))
+
+            base_price = product_data.get('base_unit_price', 0.0)
+            try:
+                self.unit_price_input.setValue(float(base_price))
+            except (ValueError, TypeError):
+                self.unit_price_input.setValue(0.0)
+
+            self.quantity_input.setValue(1.0) # Default quantity for a selected product
+            self.quantity_input.setFocus() # Set focus to quantity for quick input
+            self._update_current_line_total_preview() # Update total preview based on populated data
+
 
     def _create_icon_label_widget(self, icon_name, label_text): # Helper for icons
         widget = QWidget()
@@ -706,8 +766,24 @@ class ProductDialog(QDialog):
         header_label.setStyleSheet("font-size: 16pt; font-weight: bold; margin-bottom: 10px; color: #333;")
         main_layout.addWidget(header_label)
 
+        # Existing Product Search Group
+        search_group_box = QGroupBox(self.tr("Rechercher Produit Existant"))
+        search_layout = QVBoxLayout(search_group_box)
+
+        self.search_existing_product_input = QLineEdit()
+        self.search_existing_product_input.setPlaceholderText(self.tr("Tapez pour rechercher..."))
+        self.search_existing_product_input.textChanged.connect(self._filter_existing_products_list)
+        search_layout.addWidget(self.search_existing_product_input)
+
+        self.existing_products_list = QListWidget()
+        self.existing_products_list.setMinimumHeight(100) # Reasonable default height
+        self.existing_products_list.itemDoubleClicked.connect(self._populate_form_from_selected_product)
+        search_layout.addWidget(self.existing_products_list)
+        main_layout.addWidget(search_group_box)
+
+
         # Input Group for Current Product Line
-        input_group_box = QGroupBox(self.tr("Détails de la Ligne de Produit Actuelle"))
+        input_group_box = QGroupBox(self.tr("Détails de la Ligne de Produit Actuelle (ou Produit Sélectionné)"))
         form_layout = QFormLayout(input_group_box)
         form_layout.setSpacing(10)
 
@@ -1598,6 +1674,21 @@ class ClientWidget(QWidget):
         self.load_contacts()
         self.load_products()
 
+    def _handle_open_pdf_action(self, file_path):
+        print(f"Action: Open PDF for {file_path}")
+        # This method will now call generate_pdf_for_document
+        # client_info is available in self.client_info
+        if not self.client_info or 'client_id' not in self.client_info:
+            QMessageBox.warning(self, self.tr("Erreur Client"), self.tr("Les informations du client ne sont pas disponibles."))
+            return
+
+        generated_pdf_path = generate_pdf_for_document(file_path, self.client_info, self)
+        if generated_pdf_path:
+            QDesktopServices.openUrl(QUrl.fromLocalFile(generated_pdf_path))
+            # Optionally, refresh doc table if the PDF is saved in a way it should appear there
+            # self.populate_doc_table()
+
+
     def populate_details_layout(self):
         # Clear existing rows from details_layout if any, before repopulating
         while self.details_layout.rowCount() > 0:
@@ -1744,31 +1835,50 @@ class ClientWidget(QWidget):
                     
                     action_widget = QWidget()
                     action_layout = QHBoxLayout(action_widget)
-                    action_layout.setContentsMargins(0, 0, 0, 0)
+                    action_layout.setContentsMargins(2, 2, 2, 2) # Small margins
+                    action_layout.setSpacing(5) # Spacing between buttons
+
+                    # Button 1: Ouvrir PDF (Placeholder)
+                    pdf_btn = QPushButton("PDF") # Placeholder icon/text
+                    pdf_btn.setIcon(QIcon.fromTheme("application-pdf", QIcon("📄"))) # Fallback icon
+                    pdf_btn.setToolTip(self.tr("Ouvrir PDF du document"))
+                    pdf_btn.setFixedSize(30, 30)
+                    pdf_btn.clicked.connect(lambda _, p=file_path: self._handle_open_pdf_action(p))
+                    action_layout.addWidget(pdf_btn)
+
+                    # Button 2: Afficher Source
+                    source_btn = QPushButton("👁️") # Placeholder icon/text
+                    source_btn.setIcon(QIcon.fromTheme("document-properties", QIcon("👁️"))) # Fallback icon
+                    source_btn.setToolTip(self.tr("Afficher le fichier source"))
+                    source_btn.setFixedSize(30, 30)
+                    source_btn.clicked.connect(lambda _, p=file_path: QDesktopServices.openUrl(QUrl.fromLocalFile(p)))
+                    action_layout.addWidget(source_btn)
                     
-                    open_btn_i = QPushButton("📄")
-                    # open_btn_i.setIcon(QIcon.fromTheme("document-open")) # Icon removed
-                    open_btn_i.setToolTip(self.tr("Ouvrir le document"))
-                    open_btn_i.setFixedSize(32, 32) # Adjusted size
-                    open_btn_i.clicked.connect(lambda _, p=file_path: self.open_document(p))
-                    action_layout.addWidget(open_btn_i)
+                    # Button 3: Modifier Contenu (only for Excel/HTML)
+                    if file_name.lower().endswith(('.xlsx', '.html')):
+                        edit_btn = QPushButton("✏️")
+                        edit_btn.setIcon(QIcon.fromTheme("document-edit", QIcon("✏️"))) # Fallback icon
+                        edit_btn.setToolTip(self.tr("Modifier le contenu du document"))
+                        edit_btn.setFixedSize(30, 30)
+                        edit_btn.clicked.connect(lambda _, p=file_path: self.open_document(p)) # open_document handles editor logic
+                        action_layout.addWidget(edit_btn)
+                    else:
+                        # Add a spacer or disabled button if not editable to maintain layout consistency
+                        spacer_widget = QWidget()
+                        spacer_widget.setFixedSize(30,30)
+                        action_layout.addWidget(spacer_widget)
+
+
+                    # Button 4: Supprimer
+                    delete_btn = QPushButton("🗑️")
+                    delete_btn.setIcon(QIcon.fromTheme("edit-delete", QIcon("🗑️"))) # Fallback icon
+                    delete_btn.setToolTip(self.tr("Supprimer le document"))
+                    delete_btn.setFixedSize(30, 30)
+                    delete_btn.clicked.connect(lambda _, p=file_path: self.delete_document(p))
+                    action_layout.addWidget(delete_btn)
                     
-                    if file_name.endswith('.xlsx') or file_name.endswith('.html'): # Allow edit for HTML too
-                        edit_btn_i = QPushButton("✏️")
-                        # edit_btn_i.setIcon(QIcon.fromTheme("document-edit")) # Icon removed
-                        edit_btn_i.setToolTip(self.tr("Éditer le document"))
-                        edit_btn_i.setFixedSize(32, 32) # Adjusted size
-                        # For Excel, open_document handles ExcelEditor. For HTML, it handles HtmlEditor.
-                        edit_btn_i.clicked.connect(lambda _, p=file_path: self.open_document(p))
-                        action_layout.addWidget(edit_btn_i)
-                    
-                    delete_btn_i = QPushButton("🗑️")
-                    # delete_btn_i.setIcon(QIcon.fromTheme("edit-delete")) # Icon removed
-                    delete_btn_i.setToolTip(self.tr("Supprimer le document"))
-                    delete_btn_i.setFixedSize(32, 32) # Adjusted size
-                    delete_btn_i.clicked.connect(lambda _, p=file_path: self.delete_document(p))
-                    action_layout.addWidget(delete_btn_i)
-                    
+                    action_layout.addStretch() # Push buttons to the left if there's space
+                    action_widget.setLayout(action_layout) # Set the layout on the widget
                     self.doc_table.setCellWidget(row, 4, action_widget)
                     row += 1
 
@@ -1804,21 +1914,59 @@ class ClientWidget(QWidget):
             try:
                 # Data passed to editors is data, not UI text.
                 editor_client_data = {
-                    "Nom du client": self.client_info.get("client_name", ""),
-                    "Besoin": self.client_info.get("need", ""),
-                    "price": self.client_info.get("price", 0),
-                    "project_identifier": self.client_info.get("project_identifier", ""),
+                    "client_id": self.client_info.get("client_id"), # Crucial for DB context
+                    "Nom du client": self.client_info.get("client_name", ""), # Legacy key, keep for compatibility
+                    "client_name": self.client_info.get("client_name", ""), # Preferred key
                     "company_name": self.client_info.get("company_name", ""),
-                    "country": self.client_info.get("country", ""),
-                    "city": self.client_info.get("city", ""),
+                    "Besoin": self.client_info.get("need", ""), # 'need' is primary_need_description in client_info map
+                    "primary_need_description": self.client_info.get("need", ""), # Explicitly map
+                    "project_identifier": self.client_info.get("project_identifier", ""),
+                    "country": self.client_info.get("country", ""), # This is country_name
+                    "country_id": self.client_info.get("country_id"),
+                    "city": self.client_info.get("city", ""), # This is city_name
+                    "city_id": self.client_info.get("city_id"),
+                    "price": self.client_info.get("price", 0), # raw_price
+                    "status": self.client_info.get("status"), # status name
+                    "status_id": self.client_info.get("status_id"),
+                    "selected_languages": self.client_info.get("selected_languages"), # list
+                    "notes": self.client_info.get("notes"),
+                    "creation_date": self.client_info.get("creation_date"),
+                    "category": self.client_info.get("category"),
+                    "base_folder_path": self.client_info.get("base_folder_path")
+                    # Add any other direct fields from client_info that get_document_context_data might use
+                    # or that HtmlEditor might directly use for its own templating logic.
                 }
                 if file_path.lower().endswith('.xlsx'):
                     editor = ExcelEditor(file_path, parent=self)
-                    editor.exec_()
+                    if editor.exec_() == QDialog.Accepted:
+                        expected_pdf_basename = os.path.splitext(os.path.basename(file_path))[0] + "_" + datetime.now().strftime('%Y%m%d') + ".pdf"
+                        expected_pdf_path = os.path.join(os.path.dirname(file_path), expected_pdf_basename)
+                        if os.path.exists(expected_pdf_path):
+                            archive_timestamp = datetime.now().strftime('%Y%m%d%H%M%S')
+                            archive_pdf_name = os.path.splitext(expected_pdf_path)[0] + f"_archive_{archive_timestamp}.pdf"
+                            try:
+                                os.rename(expected_pdf_path, os.path.join(os.path.dirname(expected_pdf_path), archive_pdf_name))
+                                print(f"Archived existing PDF to: {archive_pdf_name}")
+                            except OSError as e_archive:
+                                print(f"Error archiving PDF {expected_pdf_path}: {e_archive}")
+                        generate_pdf_for_document(file_path, self.client_info, self) # This will show info message for XLSX
                     self.populate_doc_table()
                 elif file_path.lower().endswith('.html'):
                     html_editor_dialog = HtmlEditor(file_path, client_data=editor_client_data, parent=self)
-                    html_editor_dialog.exec_()
+                    if html_editor_dialog.exec_() == QDialog.Accepted:
+                        expected_pdf_basename = os.path.splitext(os.path.basename(file_path))[0] + "_" + datetime.now().strftime('%Y%m%d') + ".pdf"
+                        expected_pdf_path = os.path.join(os.path.dirname(file_path), expected_pdf_basename)
+                        if os.path.exists(expected_pdf_path):
+                            archive_timestamp = datetime.now().strftime('%Y%m%d%H%M%S')
+                            archive_pdf_name = os.path.splitext(expected_pdf_path)[0] + f"_archive_{archive_timestamp}.pdf"
+                            try:
+                                os.rename(expected_pdf_path, os.path.join(os.path.dirname(expected_pdf_path), archive_pdf_name))
+                                print(f"Archived existing PDF to: {archive_pdf_name}")
+                            except OSError as e_archive:
+                                print(f"Error archiving PDF {expected_pdf_path}: {e_archive}")
+                        generated_pdf_path = generate_pdf_for_document(file_path, self.client_info, self)
+                        if generated_pdf_path:
+                             print(f"Updated PDF generated at: {generated_pdf_path}")
                     self.populate_doc_table()
                 elif file_path.lower().endswith(('.docx', '.pdf')):
                     QDesktopServices.openUrl(QUrl.fromLocalFile(file_path))
@@ -3585,6 +3733,75 @@ class SettingsDialog(QDialog):
             "smtp_server": self.smtp_server_input_field.text(), "smtp_port": self.smtp_port_spinbox.value(),
             "smtp_user": self.smtp_user_input_field.text(), "smtp_password": self.smtp_pass_input_field.text()
         }
+
+def main():
+    if hasattr(Qt, 'AA_EnableHighDpiScaling'): QApplication.setAttribute(Qt.AA_EnableHighDpiScaling, True)
+    if hasattr(Qt, 'AA_UseHighDpiPixmaps'): QApplication.setAttribute(Qt.AA_UseHighDpiPixmaps, True)
+
+    # Determine language for translations
+    language_code = CONFIG.get("language", QLocale.system().name().split('_')[0]) # Default to system or 'en' if system locale is odd
+
+
+def generate_pdf_for_document(source_file_path: str, client_info: dict, parent_widget=None) -> str | None:
+    """
+    Generates a PDF for a given source document (HTML, XLSX, DOCX).
+    For HTML, it converts the content to PDF.
+    For XLSX/DOCX, it informs the user that direct conversion is not supported.
+    """
+    if not client_info or 'client_id' not in client_info:
+        QMessageBox.warning(parent_widget, QCoreApplication.translate("generate_pdf", "Erreur Client"),
+                            QCoreApplication.translate("generate_pdf", "ID Client manquant. Impossible de générer le PDF."))
+        return None
+
+    client_name = client_info.get('client_name', 'UnknownClient')
+    file_name, file_ext = os.path.splitext(os.path.basename(source_file_path))
+    current_date_str = datetime.now().strftime("%Y%m%d")
+    output_pdf_filename = f"{file_name}_{current_date_str}.pdf"
+    output_pdf_path = os.path.join(os.path.dirname(source_file_path), output_pdf_filename)
+
+    if file_ext.lower() == '.html':
+        try:
+            with open(source_file_path, 'r', encoding='utf-8') as f:
+                html_content = f.read()
+
+            default_company_obj = db_manager.get_default_company()
+            default_company_id = default_company_obj['company_id'] if default_company_obj else None
+            if not default_company_id:
+                 QMessageBox.information(parent_widget, QCoreApplication.translate("generate_pdf", "Avertissement"),
+                                        QCoreApplication.translate("generate_pdf", "Aucune société par défaut n'est définie. Les détails du vendeur peuvent être manquants."))
+
+            # Use HtmlEditor's static method for populating content
+            # Ensure client_info passed here is comprehensive enough for populate_html_content
+            processed_html = HtmlEditor.populate_html_content(html_content, client_info, default_company_id)
+
+            # Use the utility function for conversion
+            # base_url could be the directory of the source_file_path for relative assets
+            base_url = QUrl.fromLocalFile(os.path.dirname(source_file_path)).toString()
+            pdf_bytes = convert_html_to_pdf(processed_html, base_url=base_url)
+
+            if pdf_bytes:
+                with open(output_pdf_path, 'wb') as f_pdf:
+                    f_pdf.write(pdf_bytes)
+                QMessageBox.information(parent_widget, QCoreApplication.translate("generate_pdf", "Succès PDF"),
+                                        QCoreApplication.translate("generate_pdf", "PDF généré avec succès:\n{0}").format(output_pdf_path))
+                return output_pdf_path
+            else:
+                QMessageBox.warning(parent_widget, QCoreApplication.translate("generate_pdf", "Erreur PDF"),
+                                    QCoreApplication.translate("generate_pdf", "La conversion HTML en PDF a échoué. Le contenu PDF résultant était vide."))
+                return None
+        except Exception as e:
+            QMessageBox.critical(parent_widget, QCoreApplication.translate("generate_pdf", "Erreur HTML vers PDF"),
+                                 QCoreApplication.translate("generate_pdf", "Erreur lors de la génération du PDF à partir du HTML:\n{0}").format(str(e)))
+            return None
+    elif file_ext.lower() in ['.xlsx', '.docx']:
+        QMessageBox.information(parent_widget, QCoreApplication.translate("generate_pdf", "Fonctionnalité non disponible"),
+                                QCoreApplication.translate("generate_pdf", "La génération PDF directe pour les fichiers {0} n'est pas supportée.\nVeuillez utiliser la fonction 'Enregistrer sous PDF' ou 'Exporter vers PDF' de l'application correspondante.").format(file_ext.upper()))
+        return None
+    else:
+        QMessageBox.warning(parent_widget, QCoreApplication.translate("generate_pdf", "Type de fichier non supporté"),
+                            QCoreApplication.translate("generate_pdf", "La génération PDF n'est pas supportée pour les fichiers de type '{0}'.").format(file_ext))
+        return None
+
 
 def main():
     if hasattr(Qt, 'AA_EnableHighDpiScaling'): QApplication.setAttribute(Qt.AA_EnableHighDpiScaling, True)


### PR DESCRIPTION
This commit implements the first version of a WYSIWYG HTML editor by integrating TinyMCE into the HtmlEditor dialog.

Key changes:
- Replaced the QTextEdit in `HtmlEditor.py` with a QWebEngineView.
- Bundled TinyMCE (self-hosted GPL version) assets are expected to be in an `html_editor_assets` directory (containing `tinymce_loader.html` and the `tinymce` distribution).
- `tinymce_loader.html` initializes TinyMCE in an iframe-like mode, configured with common plugins (code, table, lists, link, image, etc.).
- JavaScript functions (`setEditorContent`, `getEditorContent`) are defined in `tinymce_loader.html` for Python to interact with the editor.
- QWebChannel (`JsBridge`) is set up for basic JS-to-Python communication (e.g., signaling TinyMCE initialization).
- `HtmlEditor._load_content` now loads the raw HTML document content (with placeholders) into the TinyMCE instance via JavaScript.
- `HtmlEditor.save_content` retrieves the raw HTML (with placeholders) from TinyMCE via JavaScript and saves it to the file, preserving the template.
- `HtmlEditor.refresh_preview` gets raw HTML from TinyMCE, processes placeholders, and displays the result in the separate preview pane.
- The old direct code editing QTextEdit and its toggle have been removed; source code editing is now available via TinyMCE's 'code' plugin.

This change provides a visual editing experience for HTML templates. Further testing and refinement, especially around complex template interactions and placeholder management within a WYSIWYG context, will be necessary.