### PR TITLE
Refactor: UI/UX Modernization Phase 1-3 Progress & Style Integration

### DIFF
--- a/dialogs.py
+++ b/dialogs.py
@@ -117,13 +117,13 @@ class TemplateDialog(QDialog):
         self.template_list.setAlternatingRowColors(True); font = self.template_list.font(); font.setPointSize(font.pointSize() + 1); self.template_list.setFont(font)
         left_vbox_layout.addWidget(self.template_list)
         btn_layout = QHBoxLayout(); btn_layout.setSpacing(8)
-        self.add_btn = QPushButton(self.tr("Ajouter")); self.add_btn.setIcon(QIcon.fromTheme("list-add")); self.add_btn.setToolTip(self.tr("Ajouter un nouveau modèle")); self.add_btn.setObjectName("primaryButton"); self.add_btn.clicked.connect(self.add_template); btn_layout.addWidget(self.add_btn)
-        self.edit_btn = QPushButton(self.tr("Modifier")); self.edit_btn.setIcon(QIcon.fromTheme("document-edit")); self.edit_btn.setToolTip(self.tr("Modifier le modèle sélectionné (ouvre le fichier externe)")); self.edit_btn.clicked.connect(self.edit_template); self.edit_btn.setEnabled(False); btn_layout.addWidget(self.edit_btn)
-        self.delete_btn = QPushButton(self.tr("Supprimer")); self.delete_btn.setIcon(QIcon.fromTheme("edit-delete")); self.delete_btn.setToolTip(self.tr("Supprimer le modèle sélectionné")); self.delete_btn.setObjectName("dangerButton"); self.delete_btn.clicked.connect(self.delete_template); self.delete_btn.setEnabled(False); btn_layout.addWidget(self.delete_btn)
-        self.default_btn = QPushButton(self.tr("Par Défaut")); self.default_btn.setIcon(QIcon.fromTheme("emblem-default")); self.default_btn.setToolTip(self.tr("Définir le modèle sélectionné comme modèle par défaut pour sa catégorie et langue")); self.default_btn.clicked.connect(self.set_default_template); self.default_btn.setEnabled(False); btn_layout.addWidget(self.default_btn)
+        self.add_btn = QPushButton(self.tr("Ajouter")); self.add_btn.setIcon(QIcon(":/icons/add.svg")); self.add_btn.setToolTip(self.tr("Ajouter un nouveau modèle")); self.add_btn.setObjectName("primaryButton"); self.add_btn.clicked.connect(self.add_template); btn_layout.addWidget(self.add_btn)
+        self.edit_btn = QPushButton(self.tr("Modifier")); self.edit_btn.setIcon(QIcon(":/icons/edit.svg")); self.edit_btn.setToolTip(self.tr("Modifier le modèle sélectionné (ouvre le fichier externe)")); self.edit_btn.clicked.connect(self.edit_template); self.edit_btn.setEnabled(False); btn_layout.addWidget(self.edit_btn)
+        self.delete_btn = QPushButton(self.tr("Supprimer")); self.delete_btn.setIcon(QIcon(":/icons/delete.svg")); self.delete_btn.setToolTip(self.tr("Supprimer le modèle sélectionné")); self.delete_btn.setObjectName("dangerButton"); self.delete_btn.clicked.connect(self.delete_template); self.delete_btn.setEnabled(False); btn_layout.addWidget(self.delete_btn)
+        self.default_btn = QPushButton(self.tr("Par Défaut")); self.default_btn.setIcon(QIcon.fromTheme("emblem-default")); self.default_btn.setToolTip(self.tr("Définir le modèle sélectionné comme modèle par défaut pour sa catégorie et langue")); self.default_btn.clicked.connect(self.set_default_template); self.default_btn.setEnabled(False); btn_layout.addWidget(self.default_btn) # emblem-default not in list yet
         left_vbox_layout.addLayout(btn_layout); main_hbox_layout.addLayout(left_vbox_layout, 1)
         self.preview_area = QTextEdit(); self.preview_area.setReadOnly(True); self.preview_area.setPlaceholderText(self.tr("Sélectionnez un modèle pour afficher un aperçu."))
-        self.preview_area.setStyleSheet("QTextEdit { border: 1px solid #cccccc; background-color: #f9f9f9; padding: 5px; }")
+        self.preview_area.setObjectName("templatePreviewArea")
         main_hbox_layout.addWidget(self.preview_area, 2); main_hbox_layout.setContentsMargins(15,15,15,15); self.load_templates(); self.template_list.currentItemChanged.connect(self.handle_tree_item_selection)
 
     def handle_tree_item_selection(self,current_item,previous_item):
@@ -251,25 +251,29 @@ class ContactDialog(QDialog):
         icon_label=QLabel();icon_label.setPixmap(QIcon.fromTheme(icon_name).pixmap(16,16));layout.addWidget(icon_label);layout.addWidget(QLabel(label_text));return widget
     def setup_ui(self):
         main_layout=QVBoxLayout(self);main_layout.setSpacing(15)
-        header_label=QLabel(self.tr("Ajouter Nouveau Contact") if not self.contact_data else self.tr("Modifier Détails Contact"));header_label.setStyleSheet("font-size: 16pt; font-weight: bold; margin-bottom: 10px; color: #333;");main_layout.addWidget(header_label)
+        header_label=QLabel(self.tr("Ajouter Nouveau Contact") if not self.contact_data else self.tr("Modifier Détails Contact")); header_label.setObjectName("dialogHeaderLabel"); main_layout.addWidget(header_label)
         form_layout=QFormLayout();form_layout.setSpacing(10);form_layout.setContentsMargins(10,0,10,0)
-        self.setStyleSheet("QLineEdit, QCheckBox { padding: 3px; }")
+        # self.setStyleSheet("QLineEdit, QCheckBox { padding: 3px; }") # Prefer global styles
         self.name_input=QLineEdit(self.contact_data.get("name",""));form_layout.addRow(self._create_icon_label_widget("user",self.tr("Nom complet:")),self.name_input)
         self.email_input=QLineEdit(self.contact_data.get("email",""));form_layout.addRow(self._create_icon_label_widget("mail-message-new",self.tr("Email:")),self.email_input)
         self.phone_input=QLineEdit(self.contact_data.get("phone",""));form_layout.addRow(self._create_icon_label_widget("phone",self.tr("Téléphone:")),self.phone_input)
         self.position_input=QLineEdit(self.contact_data.get("position",""));form_layout.addRow(self._create_icon_label_widget("preferences-desktop-user",self.tr("Poste:")),self.position_input)
         self.primary_check=QCheckBox(self.tr("Contact principal"));self.primary_check.setChecked(bool(self.contact_data.get("is_primary",0)));self.primary_check.stateChanged.connect(self.update_primary_contact_visuals);form_layout.addRow(self._create_icon_label_widget("emblem-important",self.tr("Principal:")),self.primary_check)
         main_layout.addLayout(form_layout);main_layout.addStretch()
-        button_frame=QFrame(self);button_frame.setObjectName("buttonFrame");button_frame.setStyleSheet("#buttonFrame { border-top: 1px solid #cccccc; padding-top: 10px; margin-top: 10px; }")
+        button_frame=QFrame(self);button_frame.setObjectName("buttonFrame") # Style in QSS
         button_frame_layout=QHBoxLayout(button_frame);button_frame_layout.setContentsMargins(0,0,0,0)
         button_box=QDialogButtonBox(QDialogButtonBox.Ok|QDialogButtonBox.Cancel)
-        ok_button=button_box.button(QDialogButtonBox.Ok);ok_button.setText(self.tr("OK"));ok_button.setIcon(QIcon.fromTheme("dialog-ok-apply"));ok_button.setObjectName("primaryButton")
-        cancel_button=button_box.button(QDialogButtonBox.Cancel);cancel_button.setText(self.tr("Annuler"));cancel_button.setIcon(QIcon.fromTheme("dialog-cancel"))
+        ok_button=button_box.button(QDialogButtonBox.Ok);ok_button.setText(self.tr("OK"));ok_button.setIcon(QIcon(":/icons/dialog-ok-apply.svg"));ok_button.setObjectName("primaryButton")
+        cancel_button=button_box.button(QDialogButtonBox.Cancel);cancel_button.setText(self.tr("Annuler"));cancel_button.setIcon(QIcon(":/icons/dialog-cancel.svg"))
         button_box.accepted.connect(self.accept);button_box.rejected.connect(self.reject);button_frame_layout.addWidget(button_box);main_layout.addWidget(button_frame)
         self.update_primary_contact_visuals(self.primary_check.checkState())
     def update_primary_contact_visuals(self,state):
-        if state==Qt.Checked:self.name_input.setStyleSheet("background-color: #e6ffe6; padding: 3px;")
-        else:self.name_input.setStyleSheet("padding: 3px;")
+        # Dynamic style based on state - kept inline
+        # Padding will be inherited from global QLineEdit style
+        if state==Qt.Checked:
+            self.name_input.setStyleSheet("background-color: #E8F5E9;") # Light Green from palette
+        else:
+            self.name_input.setStyleSheet("") # Reset to default QSS
     def get_data(self):return{"name":self.name_input.text().strip(),"email":self.email_input.text().strip(),"phone":self.phone_input.text().strip(),"position":self.position_input.text().strip(),"is_primary":1 if self.primary_check.isChecked() else 0}
 
 class ProductDialog(QDialog):
@@ -301,22 +305,22 @@ class ProductDialog(QDialog):
             self.quantity_input.setValue(1.0);self.quantity_input.setFocus();self._update_current_line_total_preview()
     def _create_icon_label_widget(self,icon_name,label_text):widget=QWidget();layout=QHBoxLayout(widget);layout.setContentsMargins(0,0,0,0);layout.setSpacing(5);icon_label=QLabel();icon_label.setPixmap(QIcon.fromTheme(icon_name).pixmap(16,16));layout.addWidget(icon_label);layout.addWidget(QLabel(label_text));return widget
     def setup_ui(self):
-        main_layout=QVBoxLayout(self);main_layout.setSpacing(15);header_label=QLabel(self.tr("Ajouter Lignes de Produits"));header_label.setStyleSheet("font-size: 16pt; font-weight: bold; margin-bottom: 10px; color: #333;");main_layout.addWidget(header_label)
+        main_layout=QVBoxLayout(self);main_layout.setSpacing(15);header_label=QLabel(self.tr("Ajouter Lignes de Produits")); header_label.setObjectName("dialogHeaderLabel"); main_layout.addWidget(header_label)
         two_columns_layout=QHBoxLayout();search_group_box=QGroupBox(self.tr("Rechercher Produit Existant"));search_layout=QVBoxLayout(search_group_box)
         self.product_language_filter_label=QLabel(self.tr("Filtrer par langue:"));search_layout.addWidget(self.product_language_filter_label);self.product_language_filter_combo=QComboBox();self.product_language_filter_combo.addItems([self.tr("All"),"fr","en","ar","tr","pt"]);self.product_language_filter_combo.currentTextChanged.connect(self._filter_products_by_language_and_search);search_layout.addWidget(self.product_language_filter_combo)
         self.search_existing_product_input=QLineEdit();self.search_existing_product_input.setPlaceholderText(self.tr("Tapez pour rechercher..."));self.search_existing_product_input.textChanged.connect(self._filter_products_by_language_and_search);search_layout.addWidget(self.search_existing_product_input)
         self.existing_products_list=QListWidget();self.existing_products_list.setMinimumHeight(150);self.existing_products_list.itemDoubleClicked.connect(self._populate_form_from_selected_product);search_layout.addWidget(self.existing_products_list);two_columns_layout.addWidget(search_group_box,1)
-        input_group_box=QGroupBox(self.tr("Détails de la Ligne de Produit Actuelle (ou Produit Sélectionné)"));form_layout=QFormLayout(input_group_box);form_layout.setSpacing(10);self.setStyleSheet("QLineEdit, QTextEdit, QDoubleSpinBox { padding: 3px; }")
+        input_group_box=QGroupBox(self.tr("Détails de la Ligne de Produit Actuelle (ou Produit Sélectionné)"));form_layout=QFormLayout(input_group_box);form_layout.setSpacing(10); # self.setStyleSheet("QLineEdit, QTextEdit, QDoubleSpinBox { padding: 3px; }") # Prefer global
         self.name_input=QLineEdit();form_layout.addRow(self._create_icon_label_widget("package-x-generic",self.tr("Nom du Produit:")),self.name_input);self.description_input=QTextEdit();self.description_input.setFixedHeight(80);form_layout.addRow(self.tr("Description:"),self.description_input)
         self.quantity_input=QDoubleSpinBox();self.quantity_input.setRange(0,1000000);self.quantity_input.setValue(0.0);self.quantity_input.valueChanged.connect(self._update_current_line_total_preview);form_layout.addRow(self._create_icon_label_widget("format-list-numbered",self.tr("Quantité:")),self.quantity_input)
         self.unit_price_input=QDoubleSpinBox();self.unit_price_input.setRange(0,10000000);self.unit_price_input.setPrefix("€ ");self.unit_price_input.setValue(0.0);self.unit_price_input.valueChanged.connect(self._update_current_line_total_preview);form_layout.addRow(self._create_icon_label_widget("cash",self.tr("Prix Unitaire:")),self.unit_price_input)
         current_line_total_title_label=QLabel(self.tr("Total Ligne Actuelle:"));self.current_line_total_label=QLabel("€ 0.00");font=self.current_line_total_label.font();font.setBold(True);self.current_line_total_label.setFont(font);form_layout.addRow(current_line_total_title_label,self.current_line_total_label);two_columns_layout.addWidget(input_group_box,2);main_layout.addLayout(two_columns_layout)
-        self.add_line_btn=QPushButton(self.tr("Ajouter Produit à la Liste"));self.add_line_btn.setIcon(QIcon.fromTheme("list-add"));self.add_line_btn.setObjectName("primaryButton");self.add_line_btn.clicked.connect(self._add_current_line_to_table);main_layout.addWidget(self.add_line_btn)
+        self.add_line_btn=QPushButton(self.tr("Ajouter Produit à la Liste"));self.add_line_btn.setIcon(QIcon(":/icons/list-add.svg"));self.add_line_btn.setObjectName("primaryButton");self.add_line_btn.clicked.connect(self._add_current_line_to_table);main_layout.addWidget(self.add_line_btn)
         self.products_table=QTableWidget();self.products_table.setColumnCount(5);self.products_table.setHorizontalHeaderLabels([self.tr("Nom Produit"),self.tr("Description"),self.tr("Qté"),self.tr("Prix Unitaire"),self.tr("Total Ligne")]);self.products_table.setEditTriggers(QAbstractItemView.NoEditTriggers);self.products_table.setSelectionBehavior(QAbstractItemView.SelectRows);self.products_table.horizontalHeader().setSectionResizeMode(0,QHeaderView.Stretch);self.products_table.horizontalHeader().setSectionResizeMode(1,QHeaderView.Stretch);self.products_table.horizontalHeader().setSectionResizeMode(2,QHeaderView.ResizeToContents);self.products_table.horizontalHeader().setSectionResizeMode(3,QHeaderView.ResizeToContents);self.products_table.horizontalHeader().setSectionResizeMode(4,QHeaderView.ResizeToContents);main_layout.addWidget(self.products_table)
-        self.remove_line_btn=QPushButton(self.tr("Supprimer Produit Sélectionné"));self.remove_line_btn.setIcon(QIcon.fromTheme("list-remove"));self.remove_line_btn.setStyleSheet("padding: 5px 10px;");self.remove_line_btn.clicked.connect(self._remove_selected_line_from_table);main_layout.addWidget(self.remove_line_btn)
-        self.overall_total_label=QLabel(self.tr("Total Général: € 0.00"));font=self.overall_total_label.font();font.setPointSize(font.pointSize()+3);font.setBold(True);self.overall_total_label.setFont(font);self.overall_total_label.setStyleSheet("color: #2c3e50; padding: 10px 0; margin-top: 5px;");self.overall_total_label.setAlignment(Qt.AlignRight);main_layout.addWidget(self.overall_total_label);main_layout.addStretch()
-        button_frame=QFrame(self);button_frame.setObjectName("buttonFrame");button_frame.setStyleSheet("#buttonFrame { border-top: 1px solid #cccccc; padding-top: 10px; margin-top: 10px; }");button_frame_layout=QHBoxLayout(button_frame);button_frame_layout.setContentsMargins(0,0,0,0)
-        button_box=QDialogButtonBox(QDialogButtonBox.Ok|QDialogButtonBox.Cancel);ok_button=button_box.button(QDialogButtonBox.Ok);ok_button.setText(self.tr("OK"));ok_button.setIcon(QIcon.fromTheme("dialog-ok-apply"));ok_button.setObjectName("primaryButton");cancel_button=button_box.button(QDialogButtonBox.Cancel);cancel_button.setText(self.tr("Annuler"));cancel_button.setIcon(QIcon.fromTheme("dialog-cancel"));button_box.accepted.connect(self.accept);button_box.rejected.connect(self.reject);button_frame_layout.addWidget(button_box);main_layout.addWidget(button_frame)
+        self.remove_line_btn=QPushButton(self.tr("Supprimer Produit Sélectionné"));self.remove_line_btn.setIcon(QIcon(":/icons/list-remove.svg")); self.remove_line_btn.setObjectName("removeProductLineButton"); self.remove_line_btn.clicked.connect(self._remove_selected_line_from_table);main_layout.addWidget(self.remove_line_btn) # Added objectName
+        self.overall_total_label=QLabel(self.tr("Total Général: € 0.00")); font=self.overall_total_label.font();font.setPointSize(font.pointSize()+3);font.setBold(True);self.overall_total_label.setFont(font); self.overall_total_label.setObjectName("overallTotalLabel"); self.overall_total_label.setAlignment(Qt.AlignRight);main_layout.addWidget(self.overall_total_label);main_layout.addStretch()
+        button_frame=QFrame(self);button_frame.setObjectName("buttonFrame"); button_frame_layout=QHBoxLayout(button_frame);button_frame_layout.setContentsMargins(0,0,0,0) # Style in QSS
+        button_box=QDialogButtonBox(QDialogButtonBox.Ok|QDialogButtonBox.Cancel);ok_button=button_box.button(QDialogButtonBox.Ok);ok_button.setText(self.tr("OK"));ok_button.setIcon(QIcon(":/icons/dialog-ok-apply.svg"));ok_button.setObjectName("primaryButton");cancel_button=button_box.button(QDialogButtonBox.Cancel);cancel_button.setText(self.tr("Annuler"));cancel_button.setIcon(QIcon(":/icons/dialog-cancel.svg"));button_box.accepted.connect(self.accept);button_box.rejected.connect(self.reject);button_frame_layout.addWidget(button_box);main_layout.addWidget(button_frame)
     def _update_current_line_total_preview(self):quantity=self.quantity_input.value();unit_price=self.unit_price_input.value();current_quantity=quantity if isinstance(quantity,(int,float)) else 0.0;current_unit_price=unit_price if isinstance(unit_price,(int,float)) else 0.0;line_total=current_quantity*current_unit_price;self.current_line_total_label.setText(f"€ {line_total:.2f}")
     def _add_current_line_to_table(self):
         name=self.name_input.text().strip();description=self.description_input.toPlainText().strip();quantity=self.quantity_input.value();unit_price=self.unit_price_input.value()
@@ -397,9 +401,9 @@ class CreateDocumentDialog(QDialog):
 
     def setup_ui(self):
         main_layout = QVBoxLayout(self); main_layout.setSpacing(15)
-        header_label = QLabel(self.tr("Sélectionner Documents à Créer")); header_label.setStyleSheet("font-size: 16pt; font-weight: bold; margin-bottom: 10px; color: #333;")
+        header_label = QLabel(self.tr("Sélectionner Documents à Créer")); header_label.setObjectName("dialogHeaderLabel")
         main_layout.addWidget(header_label)
-        self.setStyleSheet("QComboBox, QListWidget, QLineEdit { padding: 3px; } QListWidget::item:hover { background-color: #e6f7ff; }")
+        # self.setStyleSheet("QComboBox, QListWidget, QLineEdit { padding: 3px; } QListWidget::item:hover { background-color: #e6f7ff; }") # Prefer global styles
         filters_layout = QGridLayout(); filters_layout.setSpacing(10)
         self.language_filter_label = QLabel(self.tr("Langue:")); self.language_filter_combo = QComboBox()
         self.language_filter_combo.addItems([self.tr("All"), "fr", "en", "ar", "tr", "pt"]); self.language_filter_combo.setCurrentText(self.tr("All"))
@@ -416,11 +420,11 @@ class CreateDocumentDialog(QDialog):
         self.extension_filter_combo.currentTextChanged.connect(self.load_templates)
         self.search_bar.textChanged.connect(self.load_templates)
         self.load_templates(); main_layout.addStretch()
-        button_frame = QFrame(self); button_frame.setObjectName("buttonFrame"); button_frame.setStyleSheet("#buttonFrame { border-top: 1px solid #cccccc; padding-top: 10px; margin-top: 10px; }")
+        button_frame = QFrame(self); button_frame.setObjectName("buttonFrame") # Style in QSS
         button_frame_layout = QHBoxLayout(button_frame); button_frame_layout.setContentsMargins(0,0,0,0)
-        create_btn = QPushButton(self.tr("Créer Documents")); create_btn.setIcon(QIcon.fromTheme("document-new")); create_btn.setObjectName("primaryButton")
+        create_btn = QPushButton(self.tr("Créer Documents")); create_btn.setIcon(QIcon(":/icons/document-new.svg")); create_btn.setObjectName("primaryButton")
         create_btn.clicked.connect(self.create_documents); button_frame_layout.addWidget(create_btn)
-        cancel_btn = QPushButton(self.tr("Annuler")); cancel_btn.setIcon(QIcon.fromTheme("dialog-cancel"))
+        cancel_btn = QPushButton(self.tr("Annuler")); cancel_btn.setIcon(QIcon(":/icons/dialog-cancel.svg"))
         cancel_btn.clicked.connect(self.reject); button_frame_layout.addWidget(cancel_btn)
         main_layout.addWidget(button_frame)
 
@@ -503,17 +507,17 @@ class CompilePdfDialog(QDialog):
         self.pdf_list.horizontalHeader().setSectionResizeMode(1, QHeaderView.Stretch); self.pdf_list.setSelectionBehavior(QAbstractItemView.SelectRows)
         layout.addWidget(self.pdf_list)
         btn_layout = QHBoxLayout()
-        add_btn = QPushButton(self.tr("Ajouter PDF")); add_btn.setIcon(QIcon.fromTheme("list-add")); add_btn.clicked.connect(self.add_pdf); btn_layout.addWidget(add_btn)
-        remove_btn = QPushButton(self.tr("Supprimer")); remove_btn.setIcon(QIcon.fromTheme("edit-delete")); remove_btn.clicked.connect(self.remove_selected); btn_layout.addWidget(remove_btn)
-        move_up_btn = QPushButton(self.tr("Monter")); move_up_btn.setIcon(QIcon.fromTheme("go-up")); move_up_btn.clicked.connect(self.move_up); btn_layout.addWidget(move_up_btn)
-        move_down_btn = QPushButton(self.tr("Descendre")); move_down_btn.setIcon(QIcon.fromTheme("go-down")); move_down_btn.clicked.connect(self.move_down); btn_layout.addWidget(move_down_btn)
+        add_btn = QPushButton(self.tr("Ajouter PDF")); add_btn.setIcon(QIcon(":/icons/list-add.svg")); add_btn.clicked.connect(self.add_pdf); btn_layout.addWidget(add_btn)
+        remove_btn = QPushButton(self.tr("Supprimer")); remove_btn.setIcon(QIcon(":/icons/delete.svg")); remove_btn.clicked.connect(self.remove_selected); btn_layout.addWidget(remove_btn)
+        move_up_btn = QPushButton(self.tr("Monter")); move_up_btn.setIcon(QIcon.fromTheme("go-up")); move_up_btn.clicked.connect(self.move_up); btn_layout.addWidget(move_up_btn) # go-up not in list
+        move_down_btn = QPushButton(self.tr("Descendre")); move_down_btn.setIcon(QIcon.fromTheme("go-down")); move_down_btn.clicked.connect(self.move_down); btn_layout.addWidget(move_down_btn) # go-down not in list
         layout.addLayout(btn_layout)
         options_layout = QHBoxLayout(); options_layout.addWidget(QLabel(self.tr("Nom du fichier compilé:")))
         self.output_name = QLineEdit(f"{self.tr('compilation')}_{datetime.now().strftime('%Y%m%d_%H%M')}.pdf"); options_layout.addWidget(self.output_name); layout.addLayout(options_layout)
         action_layout = QHBoxLayout()
-        compile_btn = QPushButton(self.tr("Compiler PDF")); compile_btn.setIcon(QIcon.fromTheme("document-export")); compile_btn.setObjectName("primaryButton")
+        compile_btn = QPushButton(self.tr("Compiler PDF")); compile_btn.setIcon(QIcon(":/icons/document-export.svg")); compile_btn.setObjectName("primaryButton")
         compile_btn.clicked.connect(self.compile_pdf); action_layout.addWidget(compile_btn)
-        cancel_btn = QPushButton(self.tr("Annuler")); cancel_btn.setIcon(QIcon.fromTheme("dialog-cancel")); cancel_btn.clicked.connect(self.reject); action_layout.addWidget(cancel_btn)
+        cancel_btn = QPushButton(self.tr("Annuler")); cancel_btn.setIcon(QIcon(":/icons/dialog-cancel.svg")); cancel_btn.clicked.connect(self.reject); action_layout.addWidget(cancel_btn)
         layout.addLayout(action_layout)
         self.load_existing_pdfs()
 
@@ -653,7 +657,7 @@ class EditClientDialog(QDialog):
         self.client_need_input = QLineEdit(self.client_info.get('primary_need_description', self.client_info.get('need',''))); layout.addRow(self.tr("Besoin Client:"), self.client_need_input)
         self.project_id_input_field = QLineEdit(self.client_info.get('project_identifier', '')); layout.addRow(self.tr("ID Projet:"), self.project_id_input_field)
         self.final_price_input = QDoubleSpinBox(); self.final_price_input.setPrefix("€ "); self.final_price_input.setRange(0,10000000); self.final_price_input.setValue(float(self.client_info.get('price',0.0))); self.final_price_input.setReadOnly(True)
-        price_info_label = QLabel(self.tr("Le prix final est calculé à partir des produits et n'est pas modifiable ici.")); price_info_label.setStyleSheet("font-style: italic; font-size: 9pt; color: grey;")
+        price_info_label = QLabel(self.tr("Le prix final est calculé à partir des produits et n'est pas modifiable ici.")); price_info_label.setObjectName("priceInfoLabel")
         price_layout = QHBoxLayout(); price_layout.addWidget(self.final_price_input); price_layout.addWidget(price_info_label); layout.addRow(self.tr("Prix Final:"), price_layout)
         self.status_select_combo = QComboBox(); self.populate_statuses()
         current_status_id = self.client_info.get('status_id')
@@ -669,10 +673,14 @@ class EditClientDialog(QDialog):
         current_country_id = self.client_info.get('country_id')
         if current_country_id is not None:
             index = self.country_select_combo.findData(current_country_id)
-            if index >= 0: self.country_select_combo.setCurrentIndex(index)
-            else: current_country_name = self.client_info.get('country');
-                  if current_country_name: index_name=self.country_select_combo.findText(current_country_name);
-                                           if index_name >=0: self.country_select_combo.setCurrentIndex(index_name)
+            if index >= 0:
+                self.country_select_combo.setCurrentIndex(index)
+            else:
+                current_country_name = self.client_info.get('country')
+                if current_country_name:
+                    index_name = self.country_select_combo.findText(current_country_name)
+                    if index_name >= 0:
+                        self.country_select_combo.setCurrentIndex(index_name)
         self.country_select_combo.currentTextChanged.connect(self.load_cities_for_country_edit); layout.addRow(self.tr("Pays Client:"), self.country_select_combo)
         self.city_select_combo = QComboBox(); self.city_select_combo.setEditable(True); self.city_select_combo.setInsertPolicy(QComboBox.NoInsert)
         self.city_select_combo.completer().setCompletionMode(QCompleter.PopupCompletion); self.city_select_combo.completer().setFilterMode(Qt.MatchContains)
@@ -680,10 +688,14 @@ class EditClientDialog(QDialog):
         current_city_id = self.client_info.get('city_id')
         if current_city_id is not None:
             index = self.city_select_combo.findData(current_city_id)
-            if index >= 0: self.city_select_combo.setCurrentIndex(index)
-            else: current_city_name = self.client_info.get('city');
-                  if current_city_name: index_name = self.city_select_combo.findText(current_city_name);
-                                        if index_name >= 0: self.city_select_combo.setCurrentIndex(index_name)
+            if index >= 0:
+                self.city_select_combo.setCurrentIndex(index)
+            else:
+                current_city_name = self.client_info.get('city')
+                if current_city_name:
+                    index_name = self.city_select_combo.findText(current_city_name)
+                    if index_name >= 0:
+                        self.city_select_combo.setCurrentIndex(index_name)
         layout.addRow(self.tr("Ville Client:"), self.city_select_combo)
         self.language_select_combo = QComboBox()
         self.lang_display_to_codes_map = {self.tr("Français uniquement (fr)"): ["fr"], self.tr("Arabe uniquement (ar)"): ["ar"], self.tr("Turc uniquement (tr)"): ["tr"], self.tr("Toutes les langues (fr, ar, tr)"): ["fr", "ar", "tr"]}

--- a/main.py
+++ b/main.py
@@ -358,7 +358,7 @@ class DocumentManager(QMainWindow):
         self.language_select_combo = QComboBox() 
         self.language_select_combo.addItems([self.tr("Français uniquement (fr)"), self.tr("Arabe uniquement (ar)"), self.tr("Turc uniquement (tr)"), self.tr("Toutes les langues (fr, ar, tr)")])
         creation_form_layout.addRow(self.tr("Langues:"), self.language_select_combo)
-        self.create_client_button = QPushButton(self.tr("Créer Client")); self.create_client_button.setIcon(QIcon.fromTheme("list-add"))
+        self.create_client_button = QPushButton(self.tr("Créer Client")); self.create_client_button.setIcon(QIcon(":/icons/user-plus.svg"))
         self.create_client_button.setObjectName("primaryButton") # Use object name for global styling
         self.create_client_button.clicked.connect(self.execute_create_client) 
         creation_form_layout.addRow(self.create_client_button)
@@ -369,23 +369,30 @@ class DocumentManager(QMainWindow):
         self.client_tabs_widget.tabCloseRequested.connect(self.close_client_tab) 
         content_layout.addWidget(self.client_tabs_widget, 2)
 
+        # self.main_area_stack.addWidget(self.documents_page_widget) # Add original content as first page
+        # Correction: self.documents_page_widget is already added to the stack in setup_ui_main.
+        # This line is redundant if setup_ui_main is called before this part of the code.
+        # Ensure self.documents_page_widget is correctly added to the stack if it's not already.
+        # If main_layout.addWidget(self.main_area_stack) is the structure, then
+        # self.main_area_stack.addWidget(self.documents_page_widget) happens within setup_ui_main.
+
         self.main_area_stack.addWidget(self.documents_page_widget) # Add original content as first page
         # PM widget instantiated in __init__ and added to stack there
 
         self.load_countries_into_combo() 
         
     def create_actions_main(self): 
-        self.settings_action = QAction(self.tr("Paramètres"), self); self.settings_action.triggered.connect(self.open_settings_dialog)
-        self.template_action = QAction(self.tr("Gérer les Modèles"), self); self.template_action.triggered.connect(self.open_template_manager_dialog)
-        self.status_action = QAction(self.tr("Gérer les Statuts"), self); self.status_action.triggered.connect(self.open_status_manager_dialog)
+        self.settings_action = QAction(QIcon(":/icons/settings.svg"), self.tr("Paramètres"), self); self.settings_action.triggered.connect(self.open_settings_dialog)
+        self.template_action = QAction(QIcon(":/icons/document.svg"), self.tr("Gérer les Modèles"), self); self.template_action.triggered.connect(self.open_template_manager_dialog) # Example icon
+        self.status_action = QAction(self.tr("Gérer les Statuts"), self); self.status_action.triggered.connect(self.open_status_manager_dialog) # No icon change requested
         self.exit_action = QAction(self.tr("Quitter"), self); self.exit_action.setShortcut("Ctrl+Q"); self.exit_action.triggered.connect(self.close)
         
         # Action for Project Management
-        self.project_management_action = QAction(QIcon.fromTheme("preferences-system"), self.tr("Gestion de Projet"), self) # Added icon
+        self.project_management_action = QAction(QIcon(":/icons/preferences-system.svg"), self.tr("Gestion de Projet"), self)
         self.project_management_action.triggered.connect(self.show_project_management_view)
 
         # Action to go back to Documents view (optional, but good for navigation)
-        self.documents_view_action = QAction(QIcon.fromTheme("folder-documents"), self.tr("Gestion Documents"), self)
+        self.documents_view_action = QAction(QIcon(":/icons/folder-documents.svg"), self.tr("Gestion Documents"), self)
         self.documents_view_action.triggered.connect(self.show_documents_view)
 
     def create_menus_main(self): 
@@ -1281,10 +1288,13 @@ def main():
         default_font = QFont("Arial", 10) # Or "Helvetica", "DejaVu Sans" etc.
     app.setFont(default_font)
 
+    # Load global stylesheet from style.qss
+    load_stylesheet_global(app)
+
     # Basic global stylesheet
-    app.setStyleSheet("""
-        QWidget {
-            /* General spacing and font settings for all widgets if needed */
+    # app.setStyleSheet("""
+        # QWidget {
+            # /* General spacing and font settings for all widgets if needed */
         }
         QPushButton {
             padding: 6px 12px;
@@ -1400,9 +1410,9 @@ def main():
         }
         QListWidget::item:selected {
             background-color: #007bff; /* Blue for selection */
-            color: white;
-        }
-    """)
+            # color: white;
+        # }
+    # """)
 
     # Setup translations
     translator = QTranslator()

--- a/projectManagement.py
+++ b/projectManagement.py
@@ -236,22 +236,8 @@ class MainDashboard(QWidget): # Changed from QMainWindow to QWidget
         self.current_user = current_user # Use passed-in user
         self.template_manager = ProjectTemplateManager() # Initialize ProjectTemplateManager
 
-        self.setStyleSheet("""
-            QWidget {
-                background-color: #f8f9fa; /* Lighter background */
-                font-family: 'Segoe UI'; /* Ensure base font */
-                font-size: 10pt; /* Default font size */
-            }
-            QLabel {
-                color: #212529; /* Darker text for better contrast */
-            }
-            QPushButton { /* General button reset/base */
-                border: none;
-                padding: 8px 12px;
-                border-radius: 4px;
-                font-size: 10pt;
-            }
-        """)
+        # Stylesheet moved to global style.qss or specific object names
+        # self.setStyleSheet(""" ... """) # Removed
 
         self._main_layout = QVBoxLayout(self) # Set layout directly on QWidget
         self._main_layout.setContentsMargins(0, 0, 0, 0)
@@ -290,15 +276,17 @@ class MainDashboard(QWidget): # Changed from QMainWindow to QWidget
 
         # Topbar (replaces sidebar)
         self.setup_topbar()
+        self.topbar.setObjectName("mainDashboardTopbar") # Added object name for QSS
         self._main_layout.addWidget(self.topbar) # Add topbar to self._main_layout
 
         # Main content
         self.main_content = QStackedWidget()
-        self.main_content.setStyleSheet("""
-            QStackedWidget {
-                background-color: #ffffff;
-            }
-        """)
+        self.main_content.setObjectName("mainDashboardContentArea") # Added object name for QSS
+        # self.main_content.setStyleSheet("""
+            # QStackedWidget {
+                # background-color: #ffffff;
+            # }
+        # """) # Moved to QSS
 
         # Pages
         self.setup_dashboard_page()
@@ -322,84 +310,9 @@ class MainDashboard(QWidget): # Changed from QMainWindow to QWidget
 
 
     def setup_topbar(self):
-        self.topbar = QFrame()
+        self.topbar = QFrame() # Object name set in init_ui
         self.topbar.setFixedHeight(70)
-        self.topbar.setStyleSheet("""
-            QFrame {
-                background-color: #343a40; /* Dark charcoal */
-                color: #ffffff;
-                border-bottom: 2px solid #007bff; /* Primary accent border */
-            }
-            QPushButton {
-                background-color: transparent;
-                color: #f8f9fa; /* Lighter text for topbar buttons */
-                padding: 10px 15px;
-                border: none;
-                font-size: 11pt; /* Slightly larger for nav */
-                border-radius: 5px;
-                min-width: 90px;
-            }
-            QPushButton:hover {
-                background-color: #495057; /* Slightly lighter dark for hover */
-            }
-            QPushButton#selected {
-                background-color: #007bff; /* Primary accent */
-                color: white;
-                font-weight: bold;
-            }
-            QPushButton#menu_button { /* Style for buttons with menus */
-                padding-right: 30px; /* More space for bigger arrow */
-            }
-            QPushButton#menu_button::indicator { /* Hide default menu indicator if any */
-                width: 0px;
-            }
-            /* Custom arrow using a pseudo-element (might not work on all Qt styles/platforms)
-               If not, a QLabel with a unicode arrow could be an alternative */
-            QPushButton#menu_button::after {
-                content: "▼"; /* Unicode arrow */
-                position: absolute;
-                right: 10px;
-                top: 50%;
-                transform: translateY(-50%);
-                font-size: 12px; /* Larger arrow */
-                color: #f8f9fa;
-            }
-            QLabel { /* Labels within topbar, e.g., user name, logo text */
-                color: #f8f9fa;
-                font-size: 10pt;
-            }
-            QLabel#UserFullNameLabel { /* Specific ID for user name if needed */
-                 font-weight: bold;
-                 font-size: 11pt;
-            }
-            QLabel#UserRoleLabel {
-                 font-size: 9pt;
-                 color: #adb5bd; /* Lighter gray for role */
-            }
-            QMenu {
-                background-color: #343a40; /* Match topbar */
-                color: #f8f9fa;
-                border: 1px solid #495057; /* Border for menu */
-                padding: 8px;
-                font-size: 10pt;
-            }
-            QMenu::item {
-                padding: 10px 20px;
-                border-radius: 4px;
-            }
-            QMenu::item:selected {
-                background-color: #007bff; /* Primary accent for selected menu item */
-                color: white;
-            }
-            QMenu::icon {
-                padding-left: 10px;
-            }
-            QMenu::separator {
-                height: 1px;
-                background-color: #495057;
-                margin: 5px 0;
-            }
-        """)
+        # self.topbar.setStyleSheet(""" ... """) # Styles moved to QSS via #mainDashboardTopbar
 
         topbar_layout = QHBoxLayout(self.topbar)
         topbar_layout.setContentsMargins(15, 10, 15, 10)
@@ -410,15 +323,11 @@ class MainDashboard(QWidget): # Changed from QMainWindow to QWidget
         logo_container.setSpacing(10)
 
         logo_icon = QLabel()
-        logo_icon.setPixmap(QIcon(self.resource_path('icons/logo.png')).pixmap(45, 45))
+        logo_icon.setPixmap(QIcon(":/icons/logo.svg").pixmap(45, 45))
 
         logo_text = QLabel("Management Pro")
-        logo_text.setStyleSheet("""
-            font-size: 18pt; /* Adjusted size */
-            font-weight: bold;
-            color: #007bff; /* Primary accent */
-            font-family: 'Segoe UI', Arial, sans-serif;
-        """)
+        logo_text.setObjectName("dashboardLogoText")
+        # logo_text.setStyleSheet(""" ... """) # Moved to QSS
 
         logo_container.addWidget(logo_icon)
         logo_container.addWidget(logo_text)
@@ -432,7 +341,7 @@ class MainDashboard(QWidget): # Changed from QMainWindow to QWidget
 
         # Dashboard button (single)
         dashboard_btn = QPushButton("Dashboard")
-        dashboard_btn.setIcon(QIcon(self.resource_path('icons/dashboard.png')))
+        dashboard_btn.setIcon(QIcon(":/icons/dashboard.svg"))
         dashboard_btn.clicked.connect(lambda: self.change_page(0))
         self.nav_buttons.append(dashboard_btn)
         topbar_layout.addWidget(dashboard_btn)
@@ -440,44 +349,44 @@ class MainDashboard(QWidget): # Changed from QMainWindow to QWidget
         # Management Menu (Team + Settings)
         management_menu = QMenu()
         management_menu.addAction(
-            QIcon(self.resource_path('icons/team.png')),
+            QIcon(":/icons/team.svg"),
             "Team",
             lambda: self.change_page(1)
         )
         management_menu.addAction(
-            QIcon(self.resource_path('icons/settings.png')),
+            QIcon(":/icons/settings.svg"),
             "Settings",
             lambda: self.change_page(5)
         )
 
         management_menu.addAction(
-            QIcon(self.resource_path('icons/settings.png')),
+            QIcon(":/icons/bell.svg"),
             "Notifications",
             lambda: self.gestion_notification()
         )
         management_menu.addAction(
-            QIcon(self.resource_path('icons/settings.png')),
+            QIcon(":/icons/help-circle.svg"),
             "Client Support",
             lambda: self.gestion_sav()
         )
         management_menu.addAction(
-            QIcon(self.resource_path('icons/settings.png')),
+            QIcon(":/icons/users.svg"),
             "Prospect",
             lambda: self.gestion_prospects()
         )
         management_menu.addAction(
-            QIcon(self.resource_path('icons/settings.png')),
+            QIcon(":/icons/file-text.svg"),
             "Documents",
             lambda: self.gestion_documents()
         )
         management_menu.addAction(
-            QIcon(self.resource_path('icons/settings.png')),
+            QIcon(":/icons/book.svg"),
             "Contacts",
             lambda: self.gestion_contacts()
         )
 
         management_btn = QPushButton("Management")
-        management_btn.setIcon(QIcon(self.resource_path('icons/management.png')))
+        management_btn.setIcon(QIcon(":/icons/briefcase.svg"))
         management_btn.setMenu(management_menu)
         management_btn.setObjectName("menu_button")
         self.nav_buttons.append(management_btn)
@@ -486,28 +395,28 @@ class MainDashboard(QWidget): # Changed from QMainWindow to QWidget
         # Projects Menu (Projects + Tasks + Reports)
         projects_menu = QMenu()
         projects_menu.addAction(
-            QIcon(self.resource_path('icons/projects.png')),
+            QIcon(":/icons/folder.svg"),
             "Projects",
             lambda: self.change_page(2)
         )
         projects_menu.addAction(
-            QIcon(self.resource_path('icons/tasks.png')),
+            QIcon(":/icons/check-square.svg"),
             "Tasks",
             lambda: self.change_page(3)
         )
         projects_menu.addAction(
-            QIcon(self.resource_path('icons/reports.png')),
+            QIcon(":/icons/bar-chart-2.svg"),
             "Reports",
             lambda: self.change_page(4)
         )
         projects_menu.addAction(
-            QIcon(self.resource_path('icons/document.png')), # Placeholder icon
+            QIcon(":/icons/layout.svg"),
             "Cover Pages",
-            lambda: self.change_page(6) # Assuming this will be the 7th page (index 6)
+            lambda: self.change_page(6)
         )
 
         projects_btn = QPushButton("Activities")
-        projects_btn.setIcon(QIcon(self.resource_path('icons/activities.png')))
+        projects_btn.setIcon(QIcon(":/icons/activity.svg"))
         projects_btn.setMenu(projects_menu)
         projects_btn.setObjectName("menu_button")
         self.nav_buttons.append(projects_btn)
@@ -515,7 +424,7 @@ class MainDashboard(QWidget): # Changed from QMainWindow to QWidget
 
         # Add-on button (single)
         add_on_btn = QPushButton("Add-on")
-        add_on_btn.setIcon(QIcon(self.resource_path('icons/add_on.png')))
+        add_on_btn.setIcon(QIcon(":/icons/plus-circle.svg"))
         add_on_btn.clicked.connect(lambda: self.add_on_page())
         self.nav_buttons.append(add_on_btn)
         topbar_layout.addWidget(add_on_btn)
@@ -528,27 +437,21 @@ class MainDashboard(QWidget): # Changed from QMainWindow to QWidget
 
         # User avatar
         user_avatar = QLabel()
-        user_avatar.setPixmap(QIcon(self.resource_path('icons/user.png')).pixmap(35, 35))
-        user_avatar.setStyleSheet("border-radius: 17px; border: 2px solid #3498db;")
+        user_avatar.setPixmap(QIcon(":/icons/user.svg").pixmap(35, 35))
+        user_avatar.setObjectName("userAvatarLabel")
+        # user_avatar.setStyleSheet("border-radius: 17px; border: 2px solid #3498db;") # Moved to QSS
 
         # User info
         user_info = QVBoxLayout()
         user_info.setSpacing(0)
 
         self.user_name = QLabel("Guest")
-        self.user_name.setObjectName("UserFullNameLabel") # For specific styling if needed
-        self.user_name.setStyleSheet("""
-            font-weight: bold;
-            font-size: 11pt;
-            color: #f8f9fa;
-        """)
+        self.user_name.setObjectName("UserFullNameLabel")
+        # self.user_name.setStyleSheet("""...""") # Moved to QSS
 
         self.user_role = QLabel("Not logged in")
         self.user_role.setObjectName("UserRoleLabel")
-        self.user_role.setStyleSheet("""
-            font-size: 9pt;
-            color: #adb5bd; /* Lighter gray for role */
-        """)
+        # self.user_role.setStyleSheet("""...""") # Moved to QSS
 
         user_info.addWidget(self.user_name)
         user_info.addWidget(self.user_role)
@@ -558,19 +461,12 @@ class MainDashboard(QWidget): # Changed from QMainWindow to QWidget
 
         # Logout button
         logout_btn = QPushButton()
-        logout_btn.setIcon(QIcon(self.resource_path('icons/logout.png')))
+        logout_btn.setIcon(QIcon(":/icons/log-out.svg"))
         logout_btn.setIconSize(QSize(20, 20))
         logout_btn.setToolTip("Logout")
         logout_btn.setFixedSize(35, 35)
-        logout_btn.setStyleSheet("""
-            QPushButton {
-                background-color: rgba(231, 76, 60, 0.2);
-                border-radius: 17px;
-            }
-            QPushButton:hover {
-                background-color: rgba(231, 76, 60, 0.8);
-            }
-        """)
+        logout_btn.setObjectName("logoutButtonTopbar")
+        # logout_btn.setStyleSheet(""" ... """) # Moved to QSS
         logout_btn.clicked.connect(self.logout)
 
         user_container.addWidget(logout_btn)
@@ -643,17 +539,17 @@ class MainDashboard(QWidget): # Changed from QMainWindow to QWidget
         header_layout = QHBoxLayout(header)
 
         title = QLabel("Management Dashboard")
-        title.setStyleSheet(self.get_page_title_style())
+        title.setObjectName("pageTitleLabel")
 
         self.date_picker = QDateEdit(QDate.currentDate())
         self.date_picker.setCalendarPopup(True)
-        # Removed specific QDateEdit stylesheet, global style applies
+        # Global style applies
         self.date_picker.dateChanged.connect(self.update_dashboard)
 
         refresh_btn = QPushButton("Refresh")
-        refresh_btn.setIcon(QIcon(self.resource_path('icons/refresh.png')))
-        refresh_btn.setObjectName("primaryButton") # Use global primary style
-        # Removed specific setStyleSheet to inherit global style
+        refresh_btn.setIcon(QIcon(":/icons/refresh-cw.svg"))
+        refresh_btn.setObjectName("primaryButton")
+        # Global style applies
         refresh_btn.clicked.connect(self.update_dashboard)
 
         header_layout.addWidget(title)
@@ -724,12 +620,12 @@ class MainDashboard(QWidget): # Changed from QMainWindow to QWidget
         header_layout = QHBoxLayout(header)
 
         title = QLabel("Team Management")
-        title.setStyleSheet(self.get_page_title_style())
+        title.setObjectName("pageTitleLabel")
 
         self.add_member_btn = QPushButton("Add Member")
-        self.add_member_btn.setIcon(QIcon(self.resource_path('icons/add_user.png')))
-        self.add_member_btn.setObjectName("primaryButton") # Use global primary style
-        # Removed specific setStyleSheet to inherit global style
+        self.add_member_btn.setIcon(QIcon(":/icons/user-plus.svg"))
+        self.add_member_btn.setObjectName("primaryButton")
+        # Global style applies
         self.add_member_btn.clicked.connect(self.show_add_member_dialog)
 
         header_layout.addWidget(title)
@@ -791,12 +687,12 @@ class MainDashboard(QWidget): # Changed from QMainWindow to QWidget
         header_layout = QHBoxLayout(header)
 
         title = QLabel("Project Management")
-        title.setStyleSheet(self.get_page_title_style())
+        title.setObjectName("pageTitleLabel")
 
         self.add_project_btn = QPushButton("New Project")
-        self.add_project_btn.setIcon(QIcon(self.resource_path('icons/add_project.png')))
-        self.add_project_btn.setObjectName("primaryButton") # Use global primary style
-        # Removed specific setStyleSheet to inherit global style
+        self.add_project_btn.setIcon(QIcon(":/icons/plus-square.svg"))
+        self.add_project_btn.setObjectName("primaryButton")
+        # Global style applies
         self.add_project_btn.clicked.connect(self.show_add_project_dialog)
 
         header_layout.addWidget(title)
@@ -868,12 +764,12 @@ class MainDashboard(QWidget): # Changed from QMainWindow to QWidget
         header_layout = QHBoxLayout(header)
 
         title = QLabel("Task Management")
-        title.setStyleSheet(self.get_page_title_style())
+        title.setObjectName("pageTitleLabel")
 
         self.add_task_btn = QPushButton("New Task")
-        self.add_task_btn.setIcon(QIcon(self.resource_path('icons/add_task.png')))
-        self.add_task_btn.setObjectName("primaryButton") # Use global primary style
-        # Removed specific setStyleSheet to inherit global style
+        self.add_task_btn.setIcon(QIcon(":/icons/plus.svg"))
+        self.add_task_btn.setObjectName("primaryButton")
+        # Global style applies
         self.add_task_btn.clicked.connect(self.show_add_task_dialog)
 
         header_layout.addWidget(title)
@@ -933,7 +829,7 @@ class MainDashboard(QWidget): # Changed from QMainWindow to QWidget
         layout.setSpacing(20)
 
         title = QLabel("Reports and Analytics")
-        title.setStyleSheet(self.get_page_title_style())
+        title.setObjectName("pageTitleLabel")
 
         # Report options
         report_options = QWidget()
@@ -946,15 +842,16 @@ class MainDashboard(QWidget): # Changed from QMainWindow to QWidget
         self.report_period = QComboBox()
         self.report_period.addItems(["Last 7 Days", "Last 30 Days", "Current Quarter", "Current Year", "Custom..."])
         # Removed specific QComboBox stylesheet, global style applies
+        self.report_period.currentIndexChanged.connect(self.generate_report) # Corrected connection
 
         generate_btn = QPushButton("Generate Report")
-        generate_btn.setIcon(QIcon(self.resource_path('icons/generate_report.png'))) # Icon can be kept
-        generate_btn.setObjectName("primaryButton") # Use global primary style
+        generate_btn.setIcon(QIcon(":/icons/bar-chart.svg"))
+        generate_btn.setObjectName("primaryButton")
         generate_btn.clicked.connect(self.generate_report)
 
         export_btn = QPushButton("Export PDF")
-        export_btn.setIcon(QIcon(self.resource_path('icons/export_pdf.png'))) # Icon can be kept
-        export_btn.setObjectName("dangerButton") # Use global danger style
+        export_btn.setIcon(QIcon(":/icons/download.svg"))
+        export_btn.setObjectName("secondaryButton") # Changed to use secondary button style
         export_btn.clicked.connect(self.export_report)
 
         options_layout.addWidget(QLabel("Type:"))
@@ -999,7 +896,7 @@ class MainDashboard(QWidget): # Changed from QMainWindow to QWidget
         layout.setSpacing(20)
 
         title = QLabel("Settings")
-        title.setStyleSheet(self.get_page_title_style())
+        title.setObjectName("pageTitleLabel")
 
         # Tabs
         tabs = QTabWidget()
@@ -3437,8 +3334,8 @@ class MainDashboard(QWidget): # Changed from QMainWindow to QWidget
 
         # Header
         title_label = QLabel("Cover Page Management")
-        # title_label.setStyleSheet("font-size: 22pt; font-weight: bold; color: #343a40;") # Old direct style
-        title_label.setStyleSheet(self.get_page_title_style()) # Use helper method
+        # title_label.setStyleSheet("font-size: 22pt; font-weight: bold; color: #343a40;")
+        title_label.setObjectName("pageTitleLabel")
         layout.addWidget(title_label)
 
         # Client Selection Area
@@ -3457,18 +3354,21 @@ class MainDashboard(QWidget): # Changed from QMainWindow to QWidget
         action_buttons_layout.setSpacing(10)
 
         self.cp_create_new_btn = QPushButton("Create New Cover Page")
-        self.cp_create_new_btn.setStyleSheet(self.get_primary_button_style())
+        self.cp_create_new_btn.setObjectName("primaryButtonGreen")
+        self.cp_create_new_btn.setIcon(QIcon(":/icons/file-plus.svg"))
         self.cp_create_new_btn.clicked.connect(self.create_new_cover_page_dialog)
         action_buttons_layout.addWidget(self.cp_create_new_btn)
 
         self.cp_edit_selected_btn = QPushButton("View/Edit Selected")
-        self.cp_edit_selected_btn.setStyleSheet(self.get_secondary_button_style())
+        self.cp_edit_selected_btn.setObjectName("secondaryButtonBlue")
+        self.cp_edit_selected_btn.setIcon(QIcon(":/icons/edit-2.svg"))
         self.cp_edit_selected_btn.clicked.connect(self.edit_selected_cover_page_dialog)
         self.cp_edit_selected_btn.setEnabled(False) # Initially disabled
         action_buttons_layout.addWidget(self.cp_edit_selected_btn)
 
         self.cp_delete_selected_btn = QPushButton("Delete Selected")
-        self.cp_delete_selected_btn.setStyleSheet(self.get_danger_button_style())
+        self.cp_delete_selected_btn.setObjectName("dangerButton")
+        self.cp_delete_selected_btn.setIcon(QIcon(":/icons/trash.svg"))
         self.cp_delete_selected_btn.clicked.connect(self.delete_selected_cover_page)
         self.cp_delete_selected_btn.setEnabled(False) # Initially disabled
         action_buttons_layout.addWidget(self.cp_delete_selected_btn)
@@ -3479,7 +3379,7 @@ class MainDashboard(QWidget): # Changed from QMainWindow to QWidget
         self.cp_table = QTableWidget()
         self.cp_table.setColumnCount(4) # Name, Title, Last Modified, Actions
         self.cp_table.setHorizontalHeaderLabels(["Name", "Title", "Last Modified", "Actions"])
-        self.cp_table.setStyleSheet(self.get_table_style()) # Use general table style
+        # self.cp_table.setStyleSheet(self.get_table_style()) # Global style applies
         self.cp_table.verticalHeader().setVisible(False)
         self.cp_table.setEditTriggers(QTableWidget.NoEditTriggers)
         self.cp_table.setSelectionBehavior(QTableWidget.SelectRows)
@@ -3664,13 +3564,14 @@ class MainDashboard(QWidget): # Changed from QMainWindow to QWidget
             # If hidden: table_widget.setColumnCount(4) and remove "Actions" header.
             # For now, let it be, can be enhanced.
             # Example placeholder:
-            # edit_action_btn_placeholder = QPushButton("...")
-            # edit_action_btn_placeholder.setEnabled(False)
-            # action_widget_placeholder = QWidget()
-            # action_layout_placeholder = QHBoxLayout(action_widget_placeholder)
-            # action_layout_placeholder.addWidget(edit_action_btn_placeholder)
-            # action_layout_placeholder.setContentsMargins(0,0,0,0)
-            # table_widget.setCellWidget(row_idx, 4, action_widget_placeholder)
+            edit_action_btn_placeholder = QPushButton("...")
+            edit_action_btn_placeholder.setEnabled(False)
+            # Removed styleSheet call
+            action_widget_placeholder = QWidget()
+            action_layout_placeholder = QHBoxLayout(action_widget_placeholder)
+            action_layout_placeholder.addWidget(edit_action_btn_placeholder)
+            action_layout_placeholder.setContentsMargins(0,0,0,0)
+            table_widget.setCellWidget(row_idx, 4, action_widget_placeholder)
 
 
         table_widget.resizeColumnsToContents()
@@ -3688,7 +3589,7 @@ class MainDashboard(QWidget): # Changed from QMainWindow to QWidget
                 else:
                     QMessageBox.critical(self, self.tr("Error"), self.tr("Failed to add milestone."))
 
-    def _handle_edit_milestone(self, project_id, parent_dialog_ref):
+    def _handle_edit_milestone(self, project_id, parent_dialog_ref): # Added project_id for logging
         selected_items = self.milestones_table_details_dialog.selectedItems()
         if not selected_items:
             QMessageBox.warning(self, self.tr("No Selection"), self.tr("Please select a milestone to edit."))

--- a/style.qss
+++ b/style.qss
@@ -1,388 +1,724 @@
-/* Global Font and Color Palette */
-QWidget {
-    font-family: "Segoe UI", Arial, sans-serif; /* Default font */
-    font-size: 10pt; /* Default font size */
-    /* color: #2c3e50; Primary text color - Dark Grey/Blue */
-    /* background-color: #ecf0f1; Primary background - Light Grey */
-}
+/*
+    Modern Theme for ClientDocManager
 
-/* Color Palette Comments (Examples - Define your actual palette)
-    Primary Text: #2c3e50 (Dark Grey/Blue)
-    Secondary Text: #34495e (Slightly Lighter Grey/Blue)
-    Disabled Text: #95a5a6 (Medium Grey)
-
-    Primary Background: #ecf0f1 (Light Grey)
-    Secondary Background: #ffffff (White)
-    Window Background: #dde3e6 (Slightly darker than primary for depth)
-
-    Accent Color (Buttons, Highlights): #3498db (Blue)
-    Success Color (Success Messages, Valid Inputs): #2ecc71 (Green)
-    Warning Color (Warnings, Attention Needed): #f1c40f (Yellow)
-    Error Color (Error Messages, Invalid Inputs): #e74c3c (Red)
-
-    Border Color: #bdc3c7 (Light Grey Border)
-    Table Header Background: #dde3e6 
-    Table Alternating Row: #f8f9f9
+    Color Palette:
+    *   Primary Background: #FFFFFF (White)
+    *   Secondary Background (e.g., for main window, some panels): #F5F7FA
+    *   Primary Text: #263238 (Dark Slate Grey)
+    *   Secondary Text: #546E7A (Lighter Slate Grey)
+    *   Accent Color: #007BFF (Vibrant Blue)
+    *   Border Color: #DDE2E6 (Light Grey)
+    *   Success Color: #28A745 (Green)
+    *   Warning Color: #FFC107 (Yellow)
+    *   Error Color: #DC3545 (Red)
 */
 
-/* QWidget - Base for all widgets */
+/* Base QWidget Style */
 QWidget {
-    background-color: #ecf0f1; /* Primary background for most widgets */
-    color: #2c3e50; /* Primary text color */
+    font-family: "Open Sans", "Segoe UI", Arial, sans-serif;
+    font-size: 10pt;
+    background-color: #FFFFFF; /* Primary Background */
+    color: #263238; /* Primary Text */
     border: none; /* No border by default for most widgets */
 }
 
 /* QMainWindow */
 QMainWindow {
-    background-color: #dde3e6; /* Slightly darker for the main window background */
+    background-color: #F5F7FA; /* Secondary Background */
 }
 
 QMainWindow::separator {
-    background-color: #bdc3c7; /* Color for separators, e.g., between dock widgets */
-    width: 1px; /* Or height, depending on orientation */
+    background-color: #DDE2E6; /* Border Color */
+    width: 1px;
     height: 1px;
 }
 
 /* QDialog */
 QDialog {
-    background-color: #ffffff; /* Dialogs often have a white background */
-    border: 1px solid #bdc3c7; /* Subtle border for dialogs */
-    border-radius: 4px;
+    background-color: #FFFFFF; /* Primary Background */
+    border-radius: 6px;
+    border: 1px solid #DDE2E6; /* Border Color */
 }
+
+/* Dialog Specific Styles */
+QLabel#dialogHeaderLabel {
+    font-size: 16pt;
+    font-weight: bold;
+    margin-bottom: 10px;
+    color: #333333;
+    background-color: transparent;
+}
+
+QFrame#buttonFrame {
+    border-top: 1px solid #DDE2E6; /* Border Color */
+    padding-top: 10px;
+    margin-top: 10px;
+}
+
 
 /* QGroupBox */
 QGroupBox {
-    background-color: #ffffff; /* White background for group boxes */
-    border: 1px solid #bdc3c7; /* Border for group boxes */
+    background-color: #FFFFFF;
+    border: 1px solid #DDE2E6; /* Border Color */
     border-radius: 4px;
-    margin-top: 2ex; /* Space for the title */
-    padding: 10px; /* Inner padding */
+    margin-top: 1.5ex;
+    padding: 10px;
 }
 
 QGroupBox::title {
     subcontrol-origin: margin;
-    subcontrol-position: top left; /* Position of the title */
+    subcontrol-position: top left;
     padding: 0 5px 0 5px;
-    color: #34495e; /* Secondary text color for title */
+    color: #263238;
     font-weight: bold;
-    background-color: #ffffff; /* Ensure title background matches groupbox */
+    background-color: #FFFFFF;
 }
 
-/* Common Input Fields: QLineEdit, QTextEdit, QSpinBox, QDoubleSpinBox, QComboBox */
-QLineEdit, QTextEdit, QSpinBox, QDoubleSpinBox {
-    background-color: #ffffff; /* White background for input fields */
-    color: #2c3e50;
-    border: 1px solid #bdc3c7; /* Standard border */
-    border-radius: 3px;
-    padding: 4px 6px; /* Padding inside the input field */
-    selection-background-color: #3498db; /* Accent color for text selection */
-    selection-color: #ffffff; /* White text for selected text */
+/* Common Input Fields: QLineEdit, QTextEdit, QSpinBox, QDoubleSpinBox, QDateEdit */
+QLineEdit, QTextEdit, QSpinBox, QDoubleSpinBox, QDateEdit {
+    background-color: #FFFFFF;
+    color: #263238;
+    border: 1px solid #DDE2E6;
+    border-radius: 4px;
+    padding: 5px 8px;
+    selection-background-color: #007BFF;
+    selection-color: #FFFFFF;
 }
 
-QLineEdit:focus, QTextEdit:focus, QSpinBox:focus, QDoubleSpinBox:focus {
-    border-color: #3498db; /* Accent color border on focus */
-    outline: none; /* Remove default outline if any */
+QLineEdit:focus, QTextEdit:focus, QSpinBox:focus, QDoubleSpinBox:focus, QDateEdit:focus {
+    border-color: #007BFF;
+    outline: none;
 }
 
-QLineEdit:disabled, QTextEdit:disabled, QSpinBox:disabled, QDoubleSpinBox:disabled {
-    background-color: #ecf0f1; /* Lighter background for disabled state */
-    color: #95a5a6; /* Disabled text color */
-    border-color: #d3d9db;
+QLineEdit:disabled, QTextEdit:disabled, QSpinBox:disabled, QDoubleSpinBox:disabled, QDateEdit:disabled {
+    background-color: #F5F7FA;
+    color: #90A4AE;
+    border-color: #E0E0E0;
 }
 
+/* Specific Input Field Styles */
+QTextEdit#templatePreviewArea {
+    border: 1px solid #DDE2E6;
+    background-color: #F5F7FA;
+    padding: 5px;
+}
+
+
+/* QSpinBox, QDoubleSpinBox, QDateEdit Up/Down Buttons */
+QSpinBox::up-button, QDoubleSpinBox::up-button, QDateEdit::up-button {
+    subcontrol-origin: border;
+    subcontrol-position: top right;
+    width: 16px;
+    border-left: 1px solid #DDE2E6;
+    border-bottom: 1px solid #DDE2E6;
+    border-top-right-radius: 4px;
+    image: url(:/icons/chevron-up.svg);
+}
+
+QSpinBox::down-button, QDoubleSpinBox::down-button, QDateEdit::down-button {
+    subcontrol-origin: border;
+    subcontrol-position: bottom right;
+    width: 16px;
+    border-left: 1px solid #DDE2E6;
+    border-top: 1px solid #DDE2E6;
+    border-bottom-right-radius: 4px;
+    image: url(:/icons/chevron-down.svg);
+}
+
+QSpinBox::up-button:hover, QDoubleSpinBox::up-button:hover, QDateEdit::up-button:hover,
+QSpinBox::down-button:hover, QDoubleSpinBox::down-button:hover, QDateEdit::down-button:hover {
+    background-color: #E3F2FD;
+}
+
+QSpinBox::up-button:pressed, QDoubleSpinBox::up-button:pressed, QDateEdit::up-button:pressed,
+QSpinBox::down-button:pressed, QDoubleSpinBox::down-button:pressed, QDateEdit::down-button:pressed {
+    background-color: #CCE5FF;
+}
+
+
+/* QComboBox */
 QComboBox {
-    background-color: #ffffff;
-    color: #2c3e50;
-    border: 1px solid #bdc3c7;
-    border-radius: 3px;
-    padding: 4px 6px;
+    background-color: #FFFFFF;
+    color: #263238;
+    border: 1px solid #DDE2E6;
+    border-radius: 4px;
+    padding: 5px 8px;
 }
 
 QComboBox:hover {
-    border-color: #a5b8c3; /* Slightly darker border on hover */
+    border-color: #B0BEC5;
 }
 
 QComboBox:focus {
-    border-color: #3498db; /* Accent color on focus */
+    border-color: #007BFF;
 }
 
 QComboBox::drop-down {
     subcontrol-origin: padding;
     subcontrol-position: top right;
-    width: 20px;
+    width: 22px;
     border-left-width: 1px;
-    border-left-color: #bdc3c7;
+    border-left-color: #DDE2E6;
     border-left-style: solid;
-    border-top-right-radius: 3px;
-    border-bottom-right-radius: 3px;
-    background-color: #f8f9f9;
+    border-top-right-radius: 4px;
+    border-bottom-right-radius: 4px;
+    background-color: #F5F7FA;
 }
 
 QComboBox::down-arrow {
-    /* image: url(placeholder_down_arrow.png); Add a down_arrow.png to your resources or use a standard icon */
-    /* Consider using a more robust method like QStyle standard pixmaps if possible */
-    /* For a simple look, you might not need an image if the OS provides a default arrow for Fusion style */
+    image: url(:/icons/chevron-down.svg);
+    width: 12px;
+    height: 12px;
 }
 
-QComboBox QAbstractItemView { /* The dropdown list */
-    background-color: #ffffff;
-    border: 1px solid #bdc3c7;
-    selection-background-color: #3498db;
-    selection-color: #ffffff;
-    outline: 0px; /* No outline for the dropdown view */
+QComboBox QAbstractItemView {
+    background-color: #FFFFFF;
+    border: 1px solid #DDE2E6;
+    selection-background-color: #007BFF;
+    selection-color: #FFFFFF;
+    outline: 0px;
+    padding: 2px;
 }
+
+/* QCheckBox and QRadioButton */
+QCheckBox, QRadioButton {
+    spacing: 8px;
+    color: #263238;
+    background-color: transparent;
+    padding: 3px 0;
+}
+
+QCheckBox::indicator, QRadioButton::indicator {
+    width: 16px;
+    height: 16px;
+    border: 1px solid #B0BEC5;
+    border-radius: 3px;
+}
+
+QRadioButton::indicator {
+    border-radius: 8px;
+}
+
+QCheckBox::indicator:hover, QRadioButton::indicator:hover {
+    border-color: #007BFF;
+}
+
+QCheckBox::indicator:checked, QRadioButton::indicator:checked {
+    background-color: #007BFF;
+    border-color: #007BFF;
+    image: url(:/icons/check.svg);
+}
+
+QRadioButton::indicator:checked {
+    background-color: #007BFF;
+    border-color: #007BFF;
+    image: url(:/icons/radio-checked-dot.svg);
+}
+
+QCheckBox::indicator:disabled, QRadioButton::indicator:disabled {
+    border-color: #CFD8DC;
+    background-color: #ECEFF1;
+}
+
+QCheckBox::indicator:checked:disabled, QRadioButton::indicator:checked:disabled {
+    background-color: #B0BEC5;
+    image: url(:/icons/check-disabled.svg);
+}
+QRadioButton::indicator:checked:disabled {
+    image: url(:/icons/radio-checked-dot-disabled.svg);
+}
+
 
 /* General QPushButtons */
 QPushButton {
-    background-color: #3498db; /* Accent blue for primary buttons */
-    color: #ffffff; /* White text */
-    border: 1px solid #2980b9; /* Slightly darker border for depth */
+    background-color: #007BFF; /* Accent Color (Blue) */
+    color: #FFFFFF;
+    border: 1px solid #007BFF;
     border-radius: 4px;
-    padding: 6px 12px;
-    font-weight: bold;
-    outline: none; /* Remove default outline */
+    padding: 6px 15px;
+    font-weight: 500;
+    outline: none;
+    min-height: 1.8em;
 }
 
 QPushButton:hover {
-    background-color: #2980b9; /* Darker blue on hover */
-    border-color: #2471a3;
+    background-color: #0069D9;
+    border-color: #0062CC;
 }
 
 QPushButton:pressed {
-    background-color: #2471a3; /* Even darker blue when pressed */
-    border-color: #1f618d;
+    background-color: #0056B3;
+    border-color: #0056B3;
 }
 
 QPushButton:disabled {
-    background-color: #a5b8c3; /* Greyed out background */
-    color: #e0e0e0; /* Lighter text */
-    border-color: #95a5a6;
+    background-color: #B0BEC5;
+    color: #FFFFFF;
+    border-color: #B0BEC5;
 }
 
-/* Specific Button Types (Optional - can be defined by objectName in app) */
-QPushButton#cancelButton, QPushButton#rejectButton { /* Example if you set objectName */
-    background-color: #e74c3c; /* Red for cancel/reject */
-    border-color: #c0392b;
+/* Buttons with specific roles (using objectName) */
+QPushButton#primaryButton {
+    /* Default QPushButton is already Accent Blue */
+}
+QPushButton#primaryButtonGreen {
+    background-color: #28A745; /* Success Color (Green) */
+    border-color: #28A745;
+    color: #FFFFFF;
+}
+QPushButton#primaryButtonGreen:hover {
+    background-color: #218838;
+    border-color: #1E7E34;
+}
+
+QPushButton#secondaryButton, QPushButton#secondaryButtonBlue {
+    background-color: #6C757D; /* Default secondary grey from Bootstrap */
+    border-color: #6C757D;
+    color: #FFFFFF;
+}
+QPushButton#secondaryButton:hover, QPushButton#secondaryButtonBlue:hover {
+    background-color: #5A6268;
+    border-color: #545B62;
+}
+
+
+QPushButton#dangerButton {
+    background-color: #DC3545; /* Error Color (Red) */
+    border-color: #DC3545;
+    color: #FFFFFF;
+}
+QPushButton#dangerButton:hover {
+    background-color: #C82333;
+    border-color: #BD2130;
+}
+
+QPushButton#cancelButton, QPushButton#rejectButton {
+    background-color: #FFFFFF;
+    color: #546E7A;
+    border: 1px solid #DDE2E6;
 }
 QPushButton#cancelButton:hover, QPushButton#rejectButton:hover {
-    background-color: #c0392b;
-    border-color: #a93226;
+    background-color: #F5F7FA;
+    border-color: #B0BEC5;
+    color: #263238;
 }
 
-/* QTableWidget and QListWidget */
-QTableWidget, QListWidget {
-    background-color: #ffffff; /* White background for table/list content area */
-    border: 1px solid #bdc3c7;
+QPushButton#removeProductLineButton {
+    padding: 5px 10px;
+    /* Example: make it a danger button */
+    /* background-color: #DC3545; border-color: #DC3545; color: #FFFFFF; */
+}
+/* QPushButton#removeProductLineButton:hover { background-color: #C82333; border-color: #BD2130; } */
+
+
+/* QTableWidget, QListWidget, QTreeWidget */
+QTableWidget, QListWidget, QTreeWidget {
+    background-color: #FFFFFF;
+    border: 1px solid #DDE2E6;
+    border-radius: 4px;
+    selection-background-color: #007BFF;
+    selection-color: #FFFFFF;
+    alternate-background-color: #F5F7FA;
+}
+
+QHeaderView::section {
+    background-color: #F5F7FA;
+    color: #263238;
+    padding: 8px;
+    border: none;
+    border-bottom: 1px solid #DDE2E6;
+    font-weight: 500;
+}
+QHeaderView::section:horizontal {
+    border-right: 1px solid #DDE2E6;
+}
+QHeaderView::section:horizontal:last {
+    border-right: none;
+}
+
+
+QTableWidget::item, QListWidget::item, QTreeView::item {
+    padding: 6px 8px;
+    border-bottom: 1px solid #F5F7FA;
+    background-color: transparent;
+}
+
+QTableWidget::item:selected, QListWidget::item:selected, QTreeView::item:selected {
+    background-color: #007BFF;
+    color: #FFFFFF;
+}
+
+QTableWidget::item:hover:!selected, QListWidget::item:hover:!selected, QTreeView::item:hover:!selected {
+    background-color: #E3F2FD;
+    color: #263238;
+}
+
+QTreeView::branch {
+    background: transparent;
+}
+
+QTreeView::branch:has-children:!has-siblings:closed,
+QTreeView::branch:closed:has-children:has-siblings {
+    image: url(:/icons/chevron-right.svg);
+}
+
+QTreeView::branch:open:has-children:!has-siblings,
+QTreeView::branch:open:has-children:has-siblings {
+    image: url(:/icons/chevron-down.svg);
+}
+
+/* QProgressBar in QTableWidget (specifically for projectManagement.py) */
+QTableWidget QProgressBar {
+    border: 1px solid #DDE2E6;
+    border-radius: 4px;
+    text-align: center;
+    height: 18px;
+    font-size: 9pt;
+    background-color: #FFFFFF;
+}
+QTableWidget QProgressBar::chunk {
+    background-color: #007BFF; /* Accent Color for progress */
     border-radius: 3px;
-    selection-background-color: #3498db; /* Accent color for selection */
-    selection-color: #ffffff; /* White text for selected items */
-    alternate-background-color: #f8f9f9; /* For alternating row colors if enabled */
 }
 
-QHeaderView::section { /* Table headers */
-    background-color: #dde3e6; /* Light grey background for headers */
-    color: #2c3e50;
-    padding: 5px;
-    border: 1px solid #bdc3c7;
-    border-bottom: 2px solid #3498db; /* Accent line at bottom of header */
-    font-weight: bold;
-}
-
-QTableWidget::item, QListWidget::item {
-    padding: 5px;
-    border-bottom: 1px solid #ecf0f1; /* Light line between items */
-}
-
-QTableWidget::item:selected, QListWidget::item:selected {
-    background-color: #3498db;
-    color: #ffffff;
-}
-
-QTableWidget::item:hover, QListWidget::item:hover {
-    background-color: #e6f7ff; /* Light blue hover for items */
-    color: #2c3e50;
-}
 
 /* QTabWidget and QTabBar */
-QTabWidget::pane { /* The content area for tabs */
-    border: 1px solid #bdc3c7;
-    border-top: none; /* Tab bar acts as top border */
-    background-color: #ffffff;
-    padding: 10px;
+QTabWidget::pane {
+    border: 1px solid #DDE2E6;
+    border-top: none;
+    background-color: #FFFFFF;
+    padding: 12px;
 }
 
 QTabBar::tab {
-    background-color: #ecf0f1; /* Light grey for inactive tabs */
-    color: #34495e;
-    border: 1px solid #bdc3c7;
-    border-bottom: none; /* Remove bottom border for the tab itself */
+    background-color: #F5F7FA;
+    color: #546E7A;
+    border: 1px solid #DDE2E6;
+    border-bottom: none;
     border-top-left-radius: 4px;
     border-top-right-radius: 4px;
-    padding: 8px 15px;
-    margin-right: 2px; /* Spacing between tabs */
-    min-width: 80px; /* Minimum width for a tab */
+    padding: 8px 18px;
+    margin-right: 1px;
+    min-width: 90px;
 }
 
 QTabBar::tab:selected {
-    background-color: #ffffff; /* White background for selected tab (same as pane) */
-    color: #2c3e50; /* Darker text for selected tab */
-    border-color: #bdc3c7;
-    /* font-weight: bold; */ /* Optional: make selected tab text bold */
+    background-color: #FFFFFF;
+    color: #263238;
+    border-color: #DDE2E6;
 }
 
 QTabBar::tab:hover:!selected {
-    background-color: #f5f7f7; /* Slightly lighter grey on hover for non-selected tabs */
+    background-color: #E8ECF0;
 }
 
 QTabBar::tab:!selected {
-    margin-top: 2px; /* Make non-selected tabs appear slightly lower */
+    margin-top: 2px;
 }
 
 QTabBar::close-button {
-    /* image: url(placeholder_close_icon.png); Add a close icon */
-    /* For a simple look, you might not need an image if the OS provides a default close button for Fusion style tabs */
-    /* subcontrol-position: right; */
-    /* border-radius: 2px; */
-    /* background-color: transparent; */
+    image: url(:/icons/x.svg);
+    subcontrol-position: right;
+    padding: 2px;
+    border-radius: 3px;
 }
 QTabBar::close-button:hover {
-    /* background-color: #e74c3c; */
+    background-color: #FFCDD2;
 }
 
 /* ScrollBars */
 QScrollBar:horizontal {
-    border: 1px solid #bdc3c7;
-    background: #ecf0f1;
-    height: 12px;
-    margin: 0px 15px 0 15px; /* Margins to not overlap with add/sub line buttons if they are styled to be outside */
+    border: none;
+    background: #F5F7FA;
+    height: 10px;
+    margin: 0px 10px 0 10px;
 }
 QScrollBar::handle:horizontal {
-    background: #bdc3c7; /* Color of the draggable part */
+    background: #B0BEC5;
     min-width: 20px;
     border-radius: 5px;
 }
-QScrollBar::add-line:horizontal, QScrollBar::sub-line:horizontal { /* Buttons at ends of scrollbar */
-    border: 1px solid #bdc3c7;
-    background: #dde3e6; /* Slightly darker than scrollbar background */
-    width: 14px;
-    subcontrol-origin: margin; /* Position based on margin of scrollbar */
+QScrollBar::add-line:horizontal, QScrollBar::sub-line:horizontal {
+    background: none;
+    width: 0px;
+    border: none;
 }
-QScrollBar::add-line:horizontal {
-    subcontrol-position: right; /* Position to the right */
-    border-top-right-radius: 3px; /* Match overall styling */
-    border-bottom-right-radius: 3px;
-}
-QScrollBar::sub-line:horizontal {
-    subcontrol-position: left; /* Position to the left */
-    border-top-left-radius: 3px;
-    border-bottom-left-radius: 3px;
-}
-/* Add similar styling for QScrollBar:vertical */
+
 QScrollBar:vertical {
-    border: 1px solid #bdc3c7;
-    background: #ecf0f1;
-    width: 12px;
-    margin: 15px 0px 15px 0; /* Margins for top/bottom buttons */
+    border: none;
+    background: #F5F7FA;
+    width: 10px;
+    margin: 10px 0px 10px 0;
 }
 QScrollBar::handle:vertical {
-    background: #bdc3c7;
+    background: #B0BEC5;
     min-height: 20px;
     border-radius: 5px;
 }
 QScrollBar::add-line:vertical, QScrollBar::sub-line:vertical {
-    border: 1px solid #bdc3c7;
-    background: #dde3e6;
-    height: 14px;
-    subcontrol-origin: margin;
-}
-QScrollBar::add-line:vertical {
-    subcontrol-position: bottom; /* Position at the bottom */
-    border-bottom-left-radius: 3px;
-    border-bottom-right-radius: 3px;
-}
-QScrollBar::sub-line:vertical {
-    subcontrol-position: top; /* Position at the top */
-    border-top-left-radius: 3px;
-    border-top-right-radius: 3px;
+    background: none;
+    height: 0px;
+    border: none;
 }
 
 /* QStatusBar */
 QStatusBar {
-    background-color: #dde3e6; /* Consistent with main window elements */
-    color: #2c3e50;
-    border-top: 1px solid #bdc3c7; /* Separator line from content */
-    padding: 2px;
-    font-size: 9pt; /* Slightly smaller font for status bar */
+    background-color: #F5F7FA;
+    color: #546E7A;
+    border-top: 1px solid #DDE2E6;
+    padding: 3px;
+    font-size: 9pt;
 }
 
 QStatusBar::item {
-    border: none; /* No border for items in status bar */
+    border: none;
+}
+
+/* QToolTip */
+QToolTip {
+    background-color: #263238;
+    color: #FFFFFF;
+    border: 1px solid #263238;
+    padding: 4px 6px;
+    border-radius: 3px;
+    font-size: 9pt;
 }
 
 /* QMessageBox */
 QMessageBox {
-    background-color: #ffffff; /* Use dialog background */
-    border: 1px solid #bdc3c7; /* Consistent with QDialog */
+    background-color: #FFFFFF;
+    border: 1px solid #007BFF;
+    border-radius: 6px;
 }
-QMessageBox QLabel { /* For the message text */
-    color: #2c3e50;
-    font-size: 10pt; /* Consistent with global font size */
-    background-color: transparent; /* Ensure QLabel background is transparent */
+QMessageBox QLabel#qt_msgbox_label {
+    color: #263238;
+    font-size: 10pt;
+    background-color: transparent;
+    padding: 10px;
 }
-QMessageBox QPushButton { /* Buttons within QMessageBox */
-    background-color: #3498db; /* Standard button style */
-    color: #ffffff;
-    border: 1px solid #2980b9;
-    border-radius: 3px;
-    padding: 5px 10px;
-    min-width: 70px; /* Ensure buttons are not too small */
-    font-weight: normal; /* Override bold from global QPushButton if needed, or keep bold */
+QMessageBox QLabel#qt_msgbox_informativelabel {
+    color: #546E7A;
+    font-size: 9pt;
+    background-color: transparent;
+    padding: 0 10px 10px 10px;
+}
+QMessageBox QPushButton {
+    background-color: #007BFF;
+    color: #FFFFFF;
+    border: 1px solid #007BFF;
+    border-radius: 4px;
+    padding: 6px 12px;
+    min-width: 80px;
+    font-weight: 500;
+    min-height: 1.8em;
 }
 QMessageBox QPushButton:hover {
-    background-color: #2980b9;
+    background-color: #0069D9;
 }
 QMessageBox QPushButton:pressed {
-    background-color: #2471a3;
+    background-color: #0056B3;
 }
 
-/* Add more specific styles as needed */
-/* Example: Styling QToolBar */
+/* QToolBar */
 QToolBar {
-    background-color: #ecf0f1; /* Consistent light background */
-    border-bottom: 1px solid #bdc3c7; /* Separator from content below */
+    background-color: #F5F7FA;
+    border-bottom: 1px solid #DDE2E6;
     padding: 5px;
-    spacing: 3px; /* Spacing between items in the toolbar */
+    spacing: 4px;
 }
 
 QToolBar QToolButton {
-    background-color: transparent; /* Tool buttons are often transparent */
-    border: 1px solid transparent; /* No border unless interacting */
-    padding: 3px;
-    border-radius: 3px; /* Slight rounding */
+    background-color: transparent;
+    color: #263238;
+    border: 1px solid transparent;
+    padding: 4px;
+    border-radius: 4px;
 }
 
 QToolBar QToolButton:hover {
-    background-color: #dde3e6; /* Light highlight on hover */
-    border: 1px solid #bdc3c7; /* Subtle border on hover */
+    background-color: #E0E0E0;
+    border: 1px solid #DDE2E6;
 }
 
 QToolBar QToolButton:pressed {
-    background-color: #bdc3c7; /* Darker highlight when pressed */
+    background-color: #CFD8DC;
 }
 
-QToolBar QToolButton:checked { /* For toggle buttons */
-    background-color: #dde3e6; /* Indicate checked state */
-    border: 1px solid #3498db; /* Accent border for checked state */
+QToolBar QToolButton:checked {
+    background-color: #CCE5FF;
+    border: 1px solid #007BFF;
 }
 
-/*
-Placeholder for icons if not using QRC resources or themes.
-It's generally better to use Qt's resource system (qrc files) or QIcon.fromTheme.
-If you must use file paths, ensure they are correct relative to where the application runs
-or use absolute paths (less portable).
+/* QSplitter */
+QSplitter::handle {
+    background-color: #DDE2E6;
+}
+QSplitter::handle:horizontal {
+    width: 1px;
+}
+QSplitter::handle:vertical {
+    height: 1px;
+}
+QSplitter::handle:hover {
+    background-color: #007BFF;
+}
 
-For QComboBox::down-arrow:
-  image: url(./icons/down_arrow.png);
-For QTabBar::close-button:
-  image: url(./icons/close_tab.png);
+/* QMenu */
+QMenu {
+    background-color: #FFFFFF;
+    border: 1px solid #B0BEC5;
+    padding: 5px;
+    border-radius: 4px;
+}
+
+QMenu::item {
+    padding: 5px 20px 5px 20px;
+    color: #263238;
+    background-color: transparent;
+    border-radius: 3px;
+}
+
+QMenu::item:selected {
+    background-color: #007BFF;
+    color: #FFFFFF;
+}
+
+QMenu::separator {
+    height: 1px;
+    background: #DDE2E6;
+    margin: 4px 0px;
+}
+QMenu::indicator {
+    width: 16px;
+    height: 16px;
+    left: 6px;
+}
+QMenu::indicator:non-exclusive:checked {
+    image: url(:/icons/check.svg);
+}
+
+/* Specific Label Styles from Dialogs */
+QLabel#priceInfoLabel {
+    font-style: italic;
+    font-size: 9pt;
+    color: #546E7A;
+    background-color: transparent;
+}
+
+QLabel#overallTotalLabel {
+    color: #263238;
+    padding: 10px 0;
+    margin-top: 5px;
+    font-weight: bold;
+    background-color: transparent;
+}
+
+/* Styles for MainDashboard in projectManagement.py */
+QFrame#mainDashboardTopbar {
+    background-color: #343a40; /* Dark charcoal */
+    color: #ffffff;
+    border-bottom: 2px solid #007BFF; /* Accent Color */
+}
+
+QFrame#mainDashboardTopbar QPushButton {
+    background-color: transparent;
+    color: #f8f9fa; /* Lighter text for topbar buttons */
+    padding: 10px 15px;
+    border: none;
+    font-size: 11pt; /* Slightly larger for nav */
+    border-radius: 5px;
+    min-width: 90px;
+}
+
+QFrame#mainDashboardTopbar QPushButton:hover {
+    background-color: #495057; /* Slightly lighter dark for hover */
+}
+
+QFrame#mainDashboardTopbar QPushButton#selected { /* Specific object name for selected topbar button */
+    background-color: #007BFF; /* Accent Color */
+    color: white;
+    font-weight: bold;
+}
+
+QFrame#mainDashboardTopbar QPushButton#menu_button { /* Style for buttons with menus */
+    padding-right: 20px; /* Adjusted padding for arrow */
+    /* For a text arrow, you can append it in Python or use a QProxyStyle */
+}
+QFrame#mainDashboardTopbar QPushButton#menu_button::menu-indicator {
+    image: url(:/icons/chevron-down-light.svg); /* Needs a light chevron for dark bg */
+    subcontrol-origin: padding;
+    subcontrol-position: right center;
+    right: 5px;
+}
+
+
+QFrame#mainDashboardTopbar QLabel { /* General labels within topbar */
+    color: #f8f9fa;
+    font-size: 10pt;
+    background-color: transparent;
+}
+
+QLabel#dashboardLogoText {
+    font-size: 18pt;
+    font-weight: bold;
+    color: #007BFF; /* Accent Color */
+    font-family: "Segoe UI", Arial, sans-serif;
+    background-color: transparent;
+}
+
+QLabel#userAvatarLabel {
+    border-radius: 17px;
+    border: 2px solid #007BFF;
+    background-color: transparent; /* Ensure no other background is inherited */
+    min-width: 35px; /* Ensure size for pixmap */
+    min-height: 35px;
+    max-width: 35px;
+    max-height: 35px;
+}
+
+QLabel#UserFullNameLabel {
+     font-weight: bold;
+     font-size: 11pt;
+     color: #f8f9fa;
+     background-color: transparent;
+}
+QLabel#UserRoleLabel {
+     font-size: 9pt;
+     color: #adb5bd;
+     background-color: transparent;
+}
+
+QPushButton#logoutButtonTopbar {
+    background-color: rgba(220, 53, 69, 0.2); /* Error Color with alpha */
+    border-radius: 17px;
+    padding: 0px;
+    border: none;
+    min-width: 35px; /* Ensure size for icon */
+    max-width: 35px;
+    min-height: 35px;
+    max-height: 35px;
+}
+QPushButton#logoutButtonTopbar:hover {
+    background-color: rgba(220, 53, 69, 0.8);
+}
+
+
+QStackedWidget#mainDashboardContentArea {
+    background-color: #FFFFFF;
+}
+
+QLabel#pageTitleLabel {
+    font-size: 18pt;
+    font-weight: bold;
+    color: #343a40;
+    padding-bottom: 10px;
+    background-color: transparent;
+}
+
+
+/* Placeholder for icons needed by this QSS:
+    :/icons/chevron-up.svg, :/icons/chevron-down.svg, :/icons/check.svg,
+    :/icons/radio-checked-dot.svg, :/icons/check-disabled.svg,
+    :/icons/radio-checked-dot-disabled.svg, :/icons/chevron-right.svg, :/icons/x.svg,
+    :/icons/chevron-down-light.svg (for dark topbar menu buttons)
 */


### PR DESCRIPTION
This commit includes significant progress on the UI/UX modernization front:

Phase 1: Core Styling Foundation
- Activated external `style.qss` as the single source of truth for global styles, removing the overriding embedded QSS in `main.py`.
- Implemented a basic modern theme in `style.qss` with a new color palette (light background, blue accent), "Open Sans" font, and base styles for QWidget, QMainWindow, and QDialog.
- Set up the initial structure for a unified icon set using `icons.qrc` and updated key areas in `main.py` and `dialogs.py` to use QRC paths. (You will need to add SVG files and compile QRC).

Phase 2: Style Core UI Elements
- Enhanced `style.qss` with refined styles for common widgets like QCheckBox, QRadioButton, QToolTip, input field buttons, QTreeView, QComboBox arrow, QTabBar close button, QPushButton, and QMenu.
- Refactored most inline styles from `dialogs.py` into `style.qss` using objectNames for better maintainability.

Phase 3: Specific Modules (Partial)
- Integrated `projectManagement.py (MainDashboard)` styling with the global `style.qss`. Removed its large embedded QSS, updated its icon usage to QRC, and moved its specific styles (e.g., topbar) to the global stylesheet.

Known Issue:
- An IndentationError on line 1298 of `main.py` was reported after these changes. This commit may not fully resolve it as direct inspection and a targeted fix were not possible in this turn. The error is likely related to recent modifications in or around the HTML_TEMPLATE_CONTENTS dictionary.