### PR TITLE
Fix: Correct indentation error in EditClientDialog

### DIFF
--- a/dialogs.py
+++ b/dialogs.py
@@ -750,7 +750,8 @@ class EditClientDialog(QDialog):
         country_id = self.country_select_combo.currentData()
         if country_id is None:
             country_name = self.country_select_combo.currentText().strip()
-            if country_name: country_obj = db_manager.get_country_by_name(country_name)
+            if country_name:
+                country_obj = db_manager.get_country_by_name(country_name)
                 if country_obj: country_id = country_obj['country_id']
         data['country_id'] = country_id
         city_id = self.city_select_combo.currentData()


### PR DESCRIPTION
This commit fixes an IndentationError in the `get_data` method of the `EditClientDialog` class in `dialogs.py`. The line responsible for retrieving `country_id` when `country_obj` exists was incorrectly indented. It has now been properly nested within the conditional block that defines `country_obj`.