### PR TITLE
Fix: Correct ImportError for db_manager in client_widget.py

### DIFF
--- a/client_widget.py
+++ b/client_widget.py
@@ -12,7 +12,7 @@ from PyQt5.QtWidgets import (
 from PyQt5.QtGui import QIcon, QDesktopServices, QFont # Added QFont
 from PyQt5.QtCore import Qt, QUrl, QCoreApplication
 
-from db import db_manager
+import db as db_manager
 from excel_editor import ExcelEditor
 from html_editor import HtmlEditor
 

--- a/dialogs.py
+++ b/dialogs.py
@@ -330,10 +330,14 @@ class ProductDialog(QDialog):
         if current_lang_code==self.tr("All"):current_lang_code="fr"
         name_item.setData(Qt.UserRole+1,current_lang_code);self.products_table.setItem(row_position,0,name_item);self.products_table.setItem(row_position,1,QTableWidgetItem(description));qty_item=QTableWidgetItem(f"{quantity:.2f}");qty_item.setTextAlignment(Qt.AlignRight|Qt.AlignVCenter);self.products_table.setItem(row_position,2,qty_item);price_item=QTableWidgetItem(f"€ {unit_price:.2f}");price_item.setTextAlignment(Qt.AlignRight|Qt.AlignVCenter);self.products_table.setItem(row_position,3,price_item);total_item=QTableWidgetItem(f"€ {line_total:.2f}");total_item.setTextAlignment(Qt.AlignRight|Qt.AlignVCenter);self.products_table.setItem(row_position,4,total_item)
         self.name_input.clear();self.description_input.clear();self.quantity_input.setValue(0.0);self.unit_price_input.setValue(0.0);self._update_current_line_total_preview();self._update_overall_total();self.name_input.setFocus()
-    def _remove_selected_line_from_table(self):selected_rows=self.products_table.selectionModel().selectedRows();
-    if not selected_rows:QMessageBox.information(self,self.tr("Aucune Sélection"),self.tr("Veuillez sélectionner une ligne à supprimer."));return
-    for index in sorted(selected_rows,reverse=True):self.products_table.removeRow(index.row())
-    self._update_overall_total()
+    def _remove_selected_line_from_table(self):
+        selected_rows = self.products_table.selectionModel().selectedRows()
+        if not selected_rows:
+            QMessageBox.information(self, self.tr("Aucune Sélection"), self.tr("Veuillez sélectionner une ligne à supprimer."))
+            return
+        for index in sorted(selected_rows, reverse=True):
+            self.products_table.removeRow(index.row())
+        self._update_overall_total()
     def _update_overall_total(self):
         total_sum=0.0
         for row in range(self.products_table.rowCount()):
@@ -750,7 +754,8 @@ class EditClientDialog(QDialog):
         country_id = self.country_select_combo.currentData()
         if country_id is None:
             country_name = self.country_select_combo.currentText().strip()
-            if country_name: country_obj = db_manager.get_country_by_name(country_name)
+            if country_name:
+                country_obj = db_manager.get_country_by_name(country_name)
                 if country_obj: country_id = country_obj['country_id']
         data['country_id'] = country_id
         city_id = self.city_select_combo.currentData()


### PR DESCRIPTION
I changed the import statement in `client_widget.py` from `from db import db_manager` to `import db as db_manager`.

The `db.py` file provides database functions directly and does not define a `db_manager` object or submodule. The usage of `db_manager.<function>()` in `client_widget.py` indicates that `db_manager` is intended as an alias for the `db` module itself. This change corrects the import to reflect this intention and resolves the `ImportError: cannot import name 'db_manager' from 'db'`.