### PR TITLE
Fix: Set row_factory in initialize_database to prevent TypeError

### DIFF
--- a/db.py
+++ b/db.py
@@ -21,6 +21,7 @@ def initialize_database():
     Initializes the database by creating tables if they don't already exist.
     """
     conn = sqlite3.connect(DATABASE_NAME)
+    conn.row_factory = sqlite3.Row # <-- ADD THIS LINE
     cursor = conn.cursor()
 
     # Create Users table


### PR DESCRIPTION
The `initialize_database` function in `db.py` directly created an sqlite3 connection without setting `conn.row_factory = sqlite3.Row`. This caused issues when processing results from `PRAGMA table_info`, as it returned tuples instead of dictionary-like Row objects, leading to a `TypeError: tuple indices must be integers or slices, not str` when trying to access column metadata by name (e.g., `info['name']`).

This commit fixes the issue by adding `conn.row_factory = sqlite3.Row` immediately after the connection is established in the `initialize_database` function. This ensures that database operations within this function that fetch data will return Row objects, allowing for name-based column access and resolving the TypeError.