### PR TITLE
Fix: Resolve NameError for MAIN_MODULE_CONFIG in client_widget.py

### DIFF
--- a/app_setup.py
+++ b/app_setup.py
@@ -749,21 +749,6 @@ def initialize_default_templates(config, app_root_dir):
     if email_category_id is None:
         logging.error("CRITICAL ERROR: 'Modèles Email' category not found. Cannot register default email templates.")
     else:
-        default_email_templates_data = [
-            {
-                "name_key": "EMAIL_GREETING",
-                "display_name_prefix": {"fr": "Salutation Générale", "en": "General Greeting", "ar": "تحية عامة", "tr": "Genel Selamlama", "pt": "Saudação Geral"},
-                "subject": {
-                    "fr": "Un message de {{seller.company_name}}", "en": "A message from {{seller.company_name}}",
-                    "ar": "رسالة من {{seller.company_name}}", "tr": "{{seller.company_name}} firmasından bir mesaj",
-                    "pt": "Uma mensagem de {{seller.company_name}}"
-                },
-                "html_content": { /* Content as in main.py, truncated for brevity */ },
-                "txt_content": { /* Content as in main.py, truncated for brevity */ },
-                "description_html": { /* ... */ }, "description_txt": { /* ... */ }
-            },
-            # ... other email templates (EMAIL_FOLLOWUP etc.)
-        ]
         # Full email template data here (from main.py)
         default_email_templates_data = [
             {

--- a/client_widget.py
+++ b/client_widget.py
@@ -1,5 +1,7 @@
 # -*- coding: utf-8 -*-
 import os
+import sys
+import logging
 import shutil
 from datetime import datetime
 # import sqlite3 # No longer needed as methods are refactored to use db_manager
@@ -373,9 +375,17 @@ class ClientWidget(QWidget):
 
         # app_root_dir should be available in self.config if main.py sets it up.
         # MAIN_MODULE_CONFIG should have app_root_dir if it's set in main.py's CONFIG
-        app_root_dir = self.config.get('app_root_dir', os.path.dirname(sys.argv[0])) # Fallback, might not be ideal for frozen apps
-        if MAIN_MODULE_CONFIG and 'app_root_dir' in MAIN_MODULE_CONFIG: # Prefer this if available
-            app_root_dir = MAIN_MODULE_CONFIG['app_root_dir']
+        app_root_dir = self.app_root_dir # Directly use the stored app_root_dir
+        if app_root_dir is None: # As a safety, check if it's None
+            app_root_dir = self.config.get('app_root_dir')
+            if app_root_dir is None:
+                # Attempt to get the logger; if not available, this warning won't appear but code proceeds.
+                try:
+                    logger = logging.getLogger(__name__)
+                    logger.warning("app_root_dir not found in self.app_root_dir or self.config; falling back to path based on sys.argv[0]. This might not be reliable, especially for frozen applications.")
+                except NameError: # If logging itself isn't set up or available here.
+                    print("Warning: app_root_dir not found and logging module not available for detailed warning.")
+                app_root_dir = os.path.dirname(sys.argv[0])
 
         generated_pdf_path = self.generate_pdf_for_document(
             source_file_path=file_path,


### PR DESCRIPTION
Corrects a NameError in the `_handle_open_pdf_action` method of `client_widget.py`. The variable `MAIN_MODULE_CONFIG` was referenced without being defined in the local scope.

The method now correctly determines `app_root_dir` by prioritizing `self.app_root_dir` (passed during initialization), then falling back to `self.config.get('app_root_dir')`, and lastly to `os.path.dirname(sys.argv[0])`.

Added `import sys` and `import logging` to `client_widget.py` to support the updated logic and error reporting.