### PR TITLE
Fix: Resolve AttributeError and enhance ContactDialog

### DIFF
--- a/client_widget.py
+++ b/client_widget.py
@@ -36,9 +36,9 @@ def _import_main_elements():
            MAIN_MODULE_CONFIG, MAIN_MODULE_DATABASE_NAME, MAIN_MODULE_SEND_EMAIL_DIALOG
 
     if MAIN_MODULE_CONFIG is None: # Check one, load all if not loaded
-        import main as main_module # This is the potential circular import point
-        from dialogs import SendEmailDialog # Direct import for SendEmailDialog
-        MAIN_MODULE_CONTACT_DIALOG = main_module.ContactDialog
+        import main as main_module
+        from dialogs import SendEmailDialog, ContactDialog # Import ContactDialog directly
+        MAIN_MODULE_CONTACT_DIALOG = ContactDialog # Assign directly
         MAIN_MODULE_PRODUCT_DIALOG = main_module.ProductDialog
         MAIN_MODULE_EDIT_PRODUCT_LINE_DIALOG = main_module.EditProductLineDialog
         MAIN_MODULE_CREATE_DOCUMENT_DIALOG = main_module.CreateDocumentDialog

--- a/dialogs.py
+++ b/dialogs.py
@@ -298,6 +298,10 @@ class ContactDialog(QDialog):
         self.birthday_date_input.setPlaceholderText(self.tr("AAAA-MM-JJ ou MM-JJ"))
         additional_form_layout.addRow(self.tr("Date de naissance:"), self.birthday_date_input)
 
+        self.notes_input = QTextEdit(self.contact_data.get("notes", ""))
+        self.notes_input.setFixedHeight(60)
+        additional_form_layout.addRow(self.tr("Notes:"), self.notes_input)
+
         main_layout.addWidget(self.additional_fields_group)
 
         # Check if any additional field has data to expand the group box
@@ -305,7 +309,7 @@ class ContactDialog(QDialog):
             "givenName", "familyName", "displayName", "phone_type", "email_type",
             "address_formattedValue", "address_streetAddress", "address_city",
             "address_region", "address_postalCode", "address_country",
-            "organization_name", "organization_title", "birthday_date"
+            "organization_name", "organization_title", "birthday_date", "notes"
         ]
         # Also consider company_name and position if they were used as fallbacks and are different
         # from the main company_name/position fields, or if the specific fields are present.
@@ -355,6 +359,7 @@ class ContactDialog(QDialog):
                 "organization_name": self.organization_name_input.text().strip(),
                 "organization_title": self.organization_title_input.text().strip(),
                 "birthday_date": self.birthday_date_input.text().strip(),
+                "notes": self.notes_input.toPlainText().strip(),
             })
             # If displayName has content and main 'name' is different or empty, prioritize displayName for 'name' field in DB
             if data.get("displayName") and data.get("displayName") != data.get("name"):


### PR DESCRIPTION
This commit addresses an AttributeError in ClientWidget caused by an incorrect import of ContactDialog. ContactDialog is now imported directly from dialogs.py.

Additionally, this commit enhances the contact management features:

- Verified that the `Contacts` table schema in `db.py` already supports the required additional fields (name components, detailed address, organization, birthday, notes) without needing modifications.
- Enhanced `ContactDialog` in `dialogs.py`:
    - Added a 'Notes' QTextEdit field to the 'Additional Fields' section.
    - The 'Additional Fields' section (which includes detailed address, organization info, name components, birthday, and notes) is collapsible and hidden by default.
    - The dialog now correctly loads and saves these additional fields.
    - The 'Additional Fields' section automatically expands on dialog open if any of its contained fields have data for the contact being edited.
- Confirmed that `ClientWidget` in `client_widget.py` correctly calls `load_contacts()` after adding or editing a contact, ensuring the UI list updates immediately. The existing data handling in `ClientWidget` for passing data to and from `ContactDialog` was found to be compatible with the changes.

Testing for these changes, particularly the UI interactions and data persistence through the dialog, should be performed manually.