### PR TITLE
Fix: Correct all AttributeError issues in ClientWidget._import_main_e…

### DIFF
--- a/client_widget.py
+++ b/client_widget.py
@@ -36,17 +36,19 @@ def _import_main_elements():
            MAIN_MODULE_CONFIG, MAIN_MODULE_DATABASE_NAME, MAIN_MODULE_SEND_EMAIL_DIALOG
 
     if MAIN_MODULE_CONFIG is None: # Check one, load all if not loaded
-        import main as main_module
+        # import main as main_module # No longer needed
         from dialogs import SendEmailDialog, ContactDialog, ProductDialog, EditProductLineDialog, CreateDocumentDialog, CompilePdfDialog
         from utils import generate_pdf_for_document as utils_generate_pdf_for_document
+        from app_setup import CONFIG as APP_CONFIG
+        from db import DATABASE_NAME as DB_NAME
         MAIN_MODULE_CONTACT_DIALOG = ContactDialog # Assign directly
         MAIN_MODULE_PRODUCT_DIALOG = ProductDialog # Assign directly
         MAIN_MODULE_EDIT_PRODUCT_LINE_DIALOG = EditProductLineDialog
         MAIN_MODULE_CREATE_DOCUMENT_DIALOG = CreateDocumentDialog
         MAIN_MODULE_COMPILE_PDF_DIALOG = CompilePdfDialog
         MAIN_MODULE_GENERATE_PDF_FOR_DOCUMENT = utils_generate_pdf_for_document
-        MAIN_MODULE_CONFIG = main_module.CONFIG
-        MAIN_MODULE_DATABASE_NAME = main_module.DATABASE_NAME # Used in load_statuses, save_client_notes
+        MAIN_MODULE_CONFIG = APP_CONFIG
+        MAIN_MODULE_DATABASE_NAME = DB_NAME # Used in load_statuses, save_client_notes
         MAIN_MODULE_SEND_EMAIL_DIALOG = SendEmailDialog
 
 


### PR DESCRIPTION
…lements

This commit resolves multiple AttributeError issues within the _import_main_elements function in client_widget.py. All dialogs, utility functions, and global constants (CONFIG, DATABASE_NAME) that were previously accessed via `main_module` are now imported directly from their canonical source files (dialogs.py, utils.py, app_setup.py, db.py).

Specifically, the following elements are now directly imported:
- ContactDialog, ProductDialog, EditProductLineDialog, CreateDocumentDialog, CompilePdfDialog, SendEmailDialog (from dialogs.py)
- generate_pdf_for_document (from utils.py)
- CONFIG (from app_setup.py)
- DATABASE_NAME (from db.py)

The unnecessary `import main as main_module` line within `_import_main_elements` has been removed as it is no longer needed.

These changes enhance modularity, fix the runtime AttributeErrors, and ensure ClientWidget correctly initializes its dependencies. This also includes the previously implemented enhancements to ContactDialog (collapsible additional fields including notes, and ensuring the contact list refreshes correctly).