### PR TITLE
Fix: Correct QDialogButtonBox.Finish attribute error

### DIFF
--- a/initial_setup_dialog.py
+++ b/initial_setup_dialog.py
@@ -363,7 +363,7 @@ class InitialSetupDialog(QDialog):
         self.button_box = QDialogButtonBox()
         self.prev_button = self.button_box.addButton(QCoreApplication.translate("InitialSetupDialog", "Previous"), QDialogButtonBox.ActionRole)
         self.next_button = self.button_box.addButton(QCoreApplication.translate("InitialSetupDialog", "Next"), QDialogButtonBox.ActionRole)
-        self.finish_button = self.button_box.addButton(QDialogButtonBox.Finish)
+        self.finish_button = self.button_box.addButton(QDialogButtonBox.Ok)
         self.cancel_button = self.button_box.addButton(QDialogButtonBox.Cancel)
 
         self.prev_button.clicked.connect(self.go_previous)


### PR DESCRIPTION
The attribute QDialogButtonBox.Finish does not exist in the PyQt5 version used, leading to an AttributeError upon instantiation of InitialSetupDialog.

This commit replaces QDialogButtonBox.Finish with QDialogButtonBox.Ok, which is a valid StandardButton enum. This resolves the AttributeError and provides a semantically appropriate button (labeled "OK") for the "Finish" action in the initial setup dialog. The button's clicked signal remains connected to the existing finish_setup method.