### PR TITLE
Fix: Pass config dict to TemplateDialog, not DocumentManager instance

### DIFF
--- a/main_window.py
+++ b/main_window.py
@@ -364,7 +364,7 @@ class DocumentManager(QMainWindow):
             os.makedirs(self.config["clients_dir"], exist_ok=True)
             QMessageBox.information(self, self.tr("Paramètres Sauvegardés"), self.tr("Nouveaux paramètres enregistrés.")) # self for parent
             
-    def open_template_manager_dialog(self): TemplateDialog(self).exec_() # Pass self as parent
+    def open_template_manager_dialog(self): TemplateDialog(self.config, self).exec_() # Pass self as parent
         
     def open_status_manager_dialog(self): 
         QMessageBox.information(self, self.tr("Gestion des Statuts"), self.tr("Fonctionnalité de gestion des statuts personnalisés à implémenter."))


### PR DESCRIPTION
The TemplateDialog was being instantiated with the DocumentManager instance itself as the 'config' argument. This caused a TypeError when trying to access config['templates_dir'] because DocumentManager is not subscriptable.

This commit changes the instantiation in
DocumentManager.open_template_manager_dialog to pass self.config (the actual configuration dictionary) as the first argument and self (the DocumentManager instance) as the parent argument to TemplateDialog.