### PR TITLE
Fix: Correct 'is_primary' key access and verify dialog design

### DIFF
--- a/document_manager_logic.py
+++ b/document_manager_logic.py
@@ -187,13 +187,13 @@ def handle_create_client_execution(doc_manager):
                         else: QMessageBox.critical(doc_manager, doc_manager.tr("Erreur DB"), doc_manager.tr("Impossible de créer le nouveau contact global."))
 
                     if contact_id_to_link:
-                        if contact_form_data['is_primary']:
+                        if contact_form_data['is_primary_for_client']:
                             client_contacts = db_manager.get_contacts_for_client(actual_new_client_id)
                             if client_contacts:
                                 for cc in client_contacts:
                                     if cc['is_primary_for_client'] and cc.get('client_contact_id'):
                                         db_manager.update_client_contact_link(cc['client_contact_id'], {'is_primary_for_client': False})
-                        link_id = db_manager.link_contact_to_client(actual_new_client_id, contact_id_to_link, is_primary=contact_form_data['is_primary'])
+                        link_id = db_manager.link_contact_to_client(actual_new_client_id, contact_id_to_link, is_primary=contact_form_data['is_primary_for_client'])
                         if not link_id: QMessageBox.warning(doc_manager, doc_manager.tr("Erreur DB"), doc_manager.tr("Impossible de lier le contact au client (le lien existe peut-être déjà)."))
                 except Exception as e_contact_save:
                     QMessageBox.critical(doc_manager, doc_manager.tr("Erreur Sauvegarde Contact"), doc_manager.tr("Une erreur est survenue lors de la sauvegarde du contact : {0}").format(str(e_contact_save)))

--- a/main_window.py
+++ b/main_window.py
@@ -364,7 +364,7 @@ class DocumentManager(QMainWindow):
             os.makedirs(self.config["clients_dir"], exist_ok=True)
             QMessageBox.information(self, self.tr("Paramètres Sauvegardés"), self.tr("Nouveaux paramètres enregistrés.")) # self for parent
             
-    def open_template_manager_dialog(self): TemplateDialog(self).exec_() # Pass self as parent
+    def open_template_manager_dialog(self): TemplateDialog(self.config, self).exec_() # Pass self as parent
         
     def open_status_manager_dialog(self): 
         QMessageBox.information(self, self.tr("Gestion des Statuts"), self.tr("Fonctionnalité de gestion des statuts personnalisés à implémenter."))


### PR DESCRIPTION
- Resolved a KeyError in `document_manager_logic.py` by changing `contact_form_data['is_primary']` to `contact_form_data['is_primary_for_client']` to match the key provided by `ContactDialog.get_data()`.
- Verified that the `ContactDialog` in `dialogs.py` correctly keeps the additional fields section collapsed by default when adding a new contact, as per your feedback.