### PR TITLE
Refactor: Display document notes as numbered list

### DIFF
--- a/client_widget.py
+++ b/client_widget.py
@@ -421,9 +421,27 @@ class ClientWidget(QWidget):
 
                 self.document_notes_table.setItem(row_idx, 1, QTableWidgetItem(note.get("language_code")))
 
-                content_preview = note.get("note_content", "")
-                if len(content_preview) > 70: content_preview = content_preview[:67] + "..."
-                self.document_notes_table.setItem(row_idx, 2, QTableWidgetItem(content_preview))
+                # --- New HTML list for note content ---
+                note_content = note.get("note_content", "")
+                lines = [line.strip() for line in note_content.split('\n') if line.strip()]
+
+                html_content = ""
+                if lines:
+                    html_content = "<ol style='margin:0px; padding-left: 15px;'>" # Adjust padding as needed
+                    for line in lines:
+                        # Basic HTML escaping for safety, can be more robust if needed
+                        escaped_line = line.replace("&", "&amp;").replace("<", "&lt;").replace(">", "&gt;")
+                        html_content += f"<li>{escaped_line}</li>"
+                    html_content += "</ol>"
+                else:
+                    html_content = f"<p style='margin:0px; font-style:italic;'>{self.tr('Aucune note.')}</p>"
+
+                note_label = QLabel()
+                note_label.setText(html_content)
+                note_label.setWordWrap(True)
+                # note_label.setStyleSheet("background-color: #f0f0f0;") # Optional: for debugging layout
+                self.document_notes_table.setCellWidget(row_idx, 2, note_label)
+                # --- End new HTML list ---
 
                 active_text = self.tr("Oui") if note.get("is_active") else self.tr("Non")
                 active_item = QTableWidgetItem(active_text)

--- a/dialogs.py
+++ b/dialogs.py
@@ -2379,7 +2379,7 @@ class ClientDocumentNoteDialog(QDialog):
         form_layout.addRow(self.tr("Code Langue:"), self.language_code_combo)
 
         self.note_content_edit = QTextEdit()
-        self.note_content_edit.setPlaceholderText(self.tr("Saisissez le contenu de la note ici..."))
+        self.note_content_edit.setPlaceholderText(self.tr("Saisissez le contenu de la note ici. Chaque ligne sera affichée comme un élément d'une liste numérotée."))
         self.note_content_edit.setMinimumHeight(100)
         form_layout.addRow(self.tr("Contenu de la Note:"), self.note_content_edit)
 


### PR DESCRIPTION
This change modifies the display of client document notes. The notes, previously shown as plain text, are now rendered as an HTML ordered list in the 'Aperçu Note' column of the client's 'Notes de Document' tab.

Key changes:
- In `ClientWidget` (`client_widget.py`):
    - The `load_document_notes_table` method now processes the plain text `note_content` (fetched from the database).
    - It splits the content by newlines and constructs an HTML `<ol><li>...</li></ol>` structure.
    - A `QLabel` is used with `setCellWidget` to render this HTML in the table, allowing for numbered list display.
- In `ClientDocumentNoteDialog` (`dialogs.py`):
    - The placeholder text for the note content input field has been updated to guide you that each line will be an item in a numbered list.

No database schema changes were required, as the `note_content` continues to be stored as plain text. The formatting is applied at the presentation layer.