### PR TITLE
Fix: Prevent UnboundLocalError in ProductDialog and add app_root_dir …

### DIFF
--- a/client_widget.py
+++ b/client_widget.py
@@ -392,10 +392,6 @@ class ClientWidget(QWidget):
         self.add_doc_note_button.clicked.connect(self.on_add_document_note)
         self.refresh_doc_notes_button.clicked.connect(self.load_document_notes_table)
 
-        self.populate_doc_table(); self.load_contacts(); self.load_products()
-        self.load_document_notes_filters()
-        self.load_document_notes_table()
-
         # --- Product Dimensions Tab ---
         self.product_dimensions_tab = QWidget()
         prod_dims_layout = QVBoxLayout(self.product_dimensions_tab)
@@ -473,6 +469,10 @@ class ClientWidget(QWidget):
         self.dim_product_selector_combo.currentIndexChanged.connect(self.on_dim_product_selected)
         self.client_browse_tech_image_button.clicked.connect(self.on_client_browse_tech_image)
         self.save_client_product_dimensions_button.clicked.connect(self.on_save_client_product_dimensions)
+
+        self.populate_doc_table(); self.load_contacts(); self.load_products()
+        self.load_document_notes_filters()
+        self.load_document_notes_table()
 
 
     def load_products_for_dimension_tab(self):

--- a/dialogs.py
+++ b/dialogs.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 import os
 import json
+import logging
 import shutil
 from datetime import datetime
 import smtplib
@@ -556,6 +557,8 @@ class ProductDialog(QDialog):
         super().__init__(parent)
         self.client_id=client_id
         self.app_root_dir = app_root_dir # Store app_root_dir
+        if not self.app_root_dir or not isinstance(self.app_root_dir, str) or not self.app_root_dir.strip():
+            logging.warning("ProductDialog initialized with invalid or empty app_root_dir: %s", self.app_root_dir)
         self.current_selected_global_product_id = None
         self.setWindowTitle(self.tr("Ajouter Produits au Client"))
         self.setMinimumSize(900,800)
@@ -565,6 +568,7 @@ class ProductDialog(QDialog):
         self._filter_products_by_language_and_search()
 
     def _set_initial_language_filter(self):
+        client_langs = None
         primary_language=None
         if self.client_info:client_langs=self.client_info.get('selected_languages');
         if client_langs:primary_language=client_langs.split(',')[0].strip()


### PR DESCRIPTION
…diagnostic

- Fixed an UnboundLocalError in ProductDialog._set_initial_language_filter by initializing client_langs to None.
- Added a diagnostic log in ProductDialog.__init__ to warn if app_root_dir is not valid, helping to trace potential instantiation issues.