### PR TITLE
Fix: Handle None values in ManageProductMasterDialog form loading

### DIFF
--- a/client_widget.py
+++ b/client_widget.py
@@ -392,10 +392,6 @@ class ClientWidget(QWidget):
         self.add_doc_note_button.clicked.connect(self.on_add_document_note)
         self.refresh_doc_notes_button.clicked.connect(self.load_document_notes_table)
 
-        self.populate_doc_table(); self.load_contacts(); self.load_products()
-        self.load_document_notes_filters()
-        self.load_document_notes_table()
-
         # --- Product Dimensions Tab ---
         self.product_dimensions_tab = QWidget()
         prod_dims_layout = QVBoxLayout(self.product_dimensions_tab)
@@ -473,6 +469,10 @@ class ClientWidget(QWidget):
         self.dim_product_selector_combo.currentIndexChanged.connect(self.on_dim_product_selected)
         self.client_browse_tech_image_button.clicked.connect(self.on_client_browse_tech_image)
         self.save_client_product_dimensions_button.clicked.connect(self.on_save_client_product_dimensions)
+
+        self.populate_doc_table(); self.load_contacts(); self.load_products()
+        self.load_document_notes_filters()
+        self.load_document_notes_table()
 
 
     def load_products_for_dimension_tab(self):

--- a/dialogs.py
+++ b/dialogs.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 import os
 import json
+import logging
 import shutil
 from datetime import datetime
 import smtplib
@@ -556,6 +557,8 @@ class ProductDialog(QDialog):
         super().__init__(parent)
         self.client_id=client_id
         self.app_root_dir = app_root_dir # Store app_root_dir
+        if not self.app_root_dir or not isinstance(self.app_root_dir, str) or not self.app_root_dir.strip():
+            logging.warning("ProductDialog initialized with invalid or empty app_root_dir: %s", self.app_root_dir)
         self.current_selected_global_product_id = None
         self.setWindowTitle(self.tr("Ajouter Produits au Client"))
         self.setMinimumSize(900,800)
@@ -565,6 +568,7 @@ class ProductDialog(QDialog):
         self._filter_products_by_language_and_search()
 
     def _set_initial_language_filter(self):
+        client_langs = None
         primary_language=None
         if self.client_info:client_langs=self.client_info.get('selected_languages');
         if client_langs:primary_language=client_langs.split(',')[0].strip()
@@ -2355,8 +2359,11 @@ class ManageProductMasterDialog(QDialog):
                 lang_idx = self.language_code_combo.findText(product_data.get('language_code', 'fr'))
                 self.language_code_combo.setCurrentIndex(lang_idx if lang_idx != -1 else 0)
 
-                self.base_unit_price_input.setValue(product_data.get('base_unit_price', 0.0))
-                self.weight_input.setValue(product_data.get('weight', 0.0))
+                base_price_from_db = product_data.get('base_unit_price')
+                self.base_unit_price_input.setValue(float(base_price_from_db) if base_price_from_db is not None else 0.0)
+
+                weight_from_db = product_data.get('weight')
+                self.weight_input.setValue(float(weight_from_db) if weight_from_db is not None else 0.0)
                 self.general_dimensions_input.setText(product_data.get('dimensions', ''))
 
                 self.save_product_button.setText(self.tr("Enregistrer Modifications"))

--- a/main.py
+++ b/main.py
@@ -73,6 +73,7 @@ def check_session_timeout() -> bool:
     return False # Session is still valid
 
 def main():
+    global CURRENT_SESSION_TOKEN, CURRENT_USER_ROLE, CURRENT_USER_ID, SESSION_START_TIME
     # 1. Configure logging as the very first step.
     setup_logging()
     logging.info("Application starting...")
@@ -291,13 +292,11 @@ def main():
         session_token = login_dialog.get_session_token()
         logged_in_user = login_dialog.get_current_user()
 
-        global CURRENT_SESSION_TOKEN, CURRENT_USER_ROLE, CURRENT_USER_ID
         CURRENT_SESSION_TOKEN = session_token
         if logged_in_user:
             CURRENT_USER_ROLE = logged_in_user.get('role')
             CURRENT_USER_ID = logged_in_user.get('user_id')
             # Set session start time
-            global SESSION_START_TIME
             SESSION_START_TIME = datetime.datetime.now()
             logging.info(f"Login successful. User: {logged_in_user.get('username')}, Role: {CURRENT_USER_ROLE}, Token: {CURRENT_SESSION_TOKEN}, Session started: {SESSION_START_TIME}")
         else:


### PR DESCRIPTION
Modified ManageProductMasterDialog.on_product_selection_changed to explicitly check for None when retrieving 'base_unit_price' and 'weight' from product_data. If None, a default float value (0.0) is used before calling setValue on QDoubleSpinBox widgets.

This prevents a TypeError: setValue() argument 1 has unexpected type 'NoneType'.