### PR TITLE
feat: Enhance product modals and restructure product management access

### DIFF
--- a/projectManagement.py
+++ b/projectManagement.py
@@ -28,8 +28,9 @@ from db import get_status_setting_by_id, get_all_status_settings # For Notificat
 from PyQt5.QtWidgets import QAbstractItemView # Ensure this is imported
 import math # Added for pagination
 import json # For CoverPageEditorDialog style_config_json
-import os # For CoverPageEditorDialog logo_name
+import os # For CoverPageEditorDialog logo_name, and for app_root_dir if self.resource_path("") is not used.
 from dashboard_extensions import ProjectTemplateManager # Added for Project Templates
+from dialogs import ManageProductMasterDialog, ProductEquivalencyDialog # For Product Management
 
 
 class CustomNotificationBanner(QFrame):
@@ -368,6 +369,22 @@ class MainDashboard(QWidget): # Changed from QMainWindow to QWidget
         management_btn.setObjectName("menu_button")
         self.nav_buttons.append(management_btn)
         topbar_layout.addWidget(management_btn)
+
+        # Product Management Menu
+        product_management_btn = QPushButton("Gestion Produits")
+        product_management_btn.setIcon(QIcon(":/icons/package.svg")) # Suggestion: package.svg or similar
+        product_management_btn.setObjectName("menu_button")
+
+        product_menu = QMenu(product_management_btn)
+        manage_global_products_action = product_menu.addAction(QIcon(":/icons/box.svg"), "Gérer Produits Globaux") # Suggestion: box.svg
+        manage_global_products_action.triggered.connect(self.open_manage_global_products_dialog)
+
+        manage_equivalencies_action = product_menu.addAction(QIcon(":/icons/shuffle.svg"), "Gérer Équivalences Produits") # Suggestion: shuffle.svg or link.svg
+        manage_equivalencies_action.triggered.connect(self.open_product_equivalency_dialog)
+
+        product_management_btn.setMenu(product_menu)
+        self.nav_buttons.append(product_management_btn) # Add to nav_buttons if it should have similar styling behavior
+        topbar_layout.addWidget(product_management_btn)
 
         # Projects Menu (Projects + Tasks + Reports)
         projects_menu = QMenu()
@@ -4059,6 +4076,21 @@ if __name__ == "__main__":
             else: # Fallback
                 QMessageBox.information(self, self.tr("Project Not Found"), self.tr("Could not find project {0} in the list.").format(project_id_to_focus))
 
+    def open_manage_global_products_dialog(self):
+        try:
+            # Use self.resource_path("") to get app_root_dir, as observed in other parts of the class
+            app_root_dir = self.resource_path("")
+            dialog = ManageProductMasterDialog(app_root_dir=app_root_dir, parent=self)
+            dialog.exec_()
+        except Exception as e:
+            QMessageBox.critical(self, self.tr("Error"), self.tr("Could not open Global Product Management: {0}").format(str(e)))
+            print(f"Error opening ManageProductMasterDialog: {e}")
 
-
+    def open_product_equivalency_dialog(self):
+        try:
+            dialog = ProductEquivalencyDialog(parent=self)
+            dialog.exec_()
+        except Exception as e:
+            QMessageBox.critical(self, self.tr("Error"), self.tr("Could not open Product Equivalency Management: {0}").format(str(e)))
+            print(f"Error opening ProductEquivalencyDialog: {e}")
                 


### PR DESCRIPTION
This commit introduces the following changes:

1.  **ProductDialog (`dialogs.py`):**
    *   I added editable "Weight (Line)" (QDoubleSpinBox) and "Dimensions (Line)" (QLineEdit) fields.
    *   These fields are populated from the selected global product's data but can be overridden by you for the specific client product line.
    *   Existing read-only display labels for global product weight/dimensions have been renamed for clarity ("Weight (Global Product)", "Dimensions (Global Product)").
    *   The `get_data()` method now includes these new weight and dimensions values, along with the source global `product_id` if applicable.

2.  **EditProductLineDialog (`dialogs.py`):**
    *   I replaced previous read-only labels for weight and dimensions with an editable QDoubleSpinBox for "Weight (Line)" and QLineEdit for "Dimensions (Line)".
    *   These fields allow you to modify weight and dimensions for specific product lines already added to a client.
    *   The `get_data()` method now returns these updated values.
    *   The "View Detailed Dimensions" button text was clarified to indicate it refers to the global product's specifications.

3.  **Main Navigation (`projectManagement.py`):**
    *   I added a new "Gestion Produits" (Product Management) button to the main top bar.
    *   This button provides a dropdown menu with actions to:
        *   "Gérer Produits Globaux" (opens `ManageProductMasterDialog`).
        *   "Gérer Équivalences Produits" (opens `ProductEquivalencyDialog`).
    *   I've implemented handler methods for these actions.

4.  **ClientProductDimensionDialog (`dialogs.py`):**
    *   I verified that this dialog correctly handles the loading, editing, and saving of detailed product dimensions (A-J notation) and technical images, associated with a global `product_id`.

Note: Backend changes for persisting the new weight and dimensions fields in the `ClientProjectProducts` table (database schema and `db.py` updates) were identified as necessary but deferred from this set of UI-focused changes.