### PR TITLE
feat: Implement supplier document management

### DIFF
--- a/db/crud.py
+++ b/db/crud.py
@@ -1954,6 +1954,113 @@ def get_partners_in_category(category_id: int, conn: sqlite3.Connection = None) 
     return [dict(row) for row in cursor.fetchall()]
 # --- End PartnerCategoryLink CRUD ---
 
+# --- PartnerDocuments CRUD ---
+@_manage_conn
+def add_partner_document(data: dict, conn: sqlite3.Connection = None) -> str | None:
+    """
+    Adds a new document for a partner.
+    data keys: partner_id, document_name, file_path_relative (all required),
+               document_type, description (optional).
+    Generates a new UUID for document_id.
+    """
+    cursor = conn.cursor()
+    new_document_id = str(uuid.uuid4())
+    now = datetime.utcnow().isoformat() + "Z"
+    sql = """
+        INSERT INTO PartnerDocuments (document_id, partner_id, document_name, file_path_relative,
+                                      document_type, description, created_at, updated_at)
+        VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+    """
+    params = (
+        new_document_id,
+        data.get('partner_id'),
+        data.get('document_name'),
+        data.get('file_path_relative'),
+        data.get('document_type'),
+        data.get('description'),
+        now,
+        now
+    )
+    try:
+        if not all(data.get(k) for k in ['partner_id', 'document_name', 'file_path_relative']):
+            logging.error("partner_id, document_name, and file_path_relative are required for adding a partner document.")
+            return None
+        cursor.execute(sql, params)
+        return new_document_id
+    except sqlite3.IntegrityError as e: # Handles FK constraint on partner_id
+        logging.warning(f"Failed to add partner document, possibly invalid partner_id: {data.get('partner_id')}. Error: {e}")
+        return None
+    except sqlite3.Error as e:
+        logging.error(f"Database error in add_partner_document: {e}")
+        return None
+
+@_manage_conn
+def get_documents_for_partner(partner_id: str, conn: sqlite3.Connection = None) -> list[dict]:
+    """Retrieves all documents for a given partner_id, ordered by creation date."""
+    cursor = conn.cursor()
+    sql = "SELECT * FROM PartnerDocuments WHERE partner_id = ? ORDER BY created_at DESC"
+    cursor.execute(sql, (partner_id,))
+    return [dict(row) for row in cursor.fetchall()]
+
+@_manage_conn
+def get_partner_document_by_id(document_id: str, conn: sqlite3.Connection = None) -> dict | None:
+    """Retrieves a specific partner document by its document_id."""
+    cursor = conn.cursor()
+    sql = "SELECT * FROM PartnerDocuments WHERE document_id = ?"
+    cursor.execute(sql, (document_id,))
+    row = cursor.fetchone()
+    return dict(row) if row else None
+
+@_manage_conn
+def update_partner_document(document_id: str, data: dict, conn: sqlite3.Connection = None) -> bool:
+    """
+    Updates a partner document.
+    data can contain: document_name, document_type, description.
+    """
+    if not data or not any(k in data for k in ['document_name', 'document_type', 'description']):
+        logging.info("No updatable fields provided for update_partner_document.")
+        return False # Nothing to update or only irrelevant fields
+
+    cursor = conn.cursor()
+    now = datetime.utcnow().isoformat() + "Z"
+
+    update_fields = {}
+    if 'document_name' in data:
+        update_fields['document_name'] = data['document_name']
+    if 'document_type' in data:
+        update_fields['document_type'] = data['document_type']
+    if 'description' in data:
+        update_fields['description'] = data['description']
+
+    if not update_fields: # Should be caught by the initial check, but as a safeguard
+        return False
+
+    update_fields['updated_at'] = now
+
+    set_clauses = [f"{key} = ?" for key in update_fields.keys()]
+    params = list(update_fields.values())
+    params.append(document_id)
+
+    sql = f"UPDATE PartnerDocuments SET {', '.join(set_clauses)} WHERE document_id = ?"
+    try:
+        cursor.execute(sql, tuple(params))
+        return cursor.rowcount > 0
+    except sqlite3.Error as e:
+        logging.error(f"Database error in update_partner_document for {document_id}: {e}")
+        return False
+
+@_manage_conn
+def delete_partner_document(document_id: str, conn: sqlite3.Connection = None) -> bool:
+    """Deletes a partner document by its document_id."""
+    cursor = conn.cursor()
+    sql = "DELETE FROM PartnerDocuments WHERE document_id = ?"
+    try:
+        cursor.execute(sql, (document_id,))
+        return cursor.rowcount > 0
+    except sqlite3.Error as e:
+        logging.error(f"Database error in delete_partner_document for {document_id}: {e}")
+        return False
+# --- End PartnerDocuments CRUD ---
 
 @_manage_conn
 def add_activity_log(data: dict, conn: sqlite3.Connection = None) -> int | None:
@@ -2077,6 +2184,10 @@ __all__ = [
     # PartnerCategoryLink
     "link_partner_to_category", "unlink_partner_from_category",
     "get_categories_for_partner", "get_partners_in_category",
+
+    # Partner Documents
+    "add_partner_document", "get_documents_for_partner", "get_partner_document_by_id",
+    "update_partner_document", "delete_partner_document",
 
     # _get_or_create_category_id is internal to schema.py, not exposed via crud
     # _populate_default_cover_page_templates is internal to schema.py

--- a/db/schema.py
+++ b/db/schema.py
@@ -207,6 +207,20 @@ def initialize_database():
             FOREIGN KEY (category_id) REFERENCES PartnerCategories(category_id) ON DELETE CASCADE
         )
     """)
+
+    cursor.execute("""
+        CREATE TABLE IF NOT EXISTS PartnerDocuments (
+            document_id TEXT PRIMARY KEY,
+            partner_id TEXT NOT NULL,
+            document_name TEXT NOT NULL,
+            file_path_relative TEXT NOT NULL,
+            document_type TEXT,
+            description TEXT,
+            created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+            updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+            FOREIGN KEY (partner_id) REFERENCES Partners(partner_id) ON DELETE CASCADE
+        )
+    """)
     # --- End New Partner Tables ---
 
     cursor.execute("CREATE TABLE IF NOT EXISTS TemplateCategories (category_id INTEGER PRIMARY KEY AUTOINCREMENT, category_name TEXT NOT NULL UNIQUE, description TEXT)")
@@ -259,6 +273,7 @@ def initialize_database():
     cursor.execute("CREATE INDEX IF NOT EXISTS idx_partners_email ON Partners(email)")
     cursor.execute("CREATE INDEX IF NOT EXISTS idx_partnercontacts_partner_id ON PartnerContacts(partner_id)")
     cursor.execute("CREATE INDEX IF NOT EXISTS idx_partnercategorylink_category_id ON PartnerCategoryLink(category_id)")
+    cursor.execute("CREATE INDEX IF NOT EXISTS idx_partnerdocuments_partner_id ON PartnerDocuments(partner_id)")
     # --- End Indexes for New Partner Tables ---
 
     # --- Seed Data ---

--- a/db_config.py
+++ b/db_config.py
@@ -23,6 +23,9 @@ DEFAULT_ADMIN_USERNAME = "admin"
 # In a real app, use a more secure default, an environment variable, or prompt user during setup.
 DEFAULT_ADMIN_PASSWORD = "adminpassword" # Changed from "admin_password" to match original db.py seeding logic
 
+# --- Partner Documents Configuration ---
+PARTNERS_DOCUMENTS_DIR = os.path.join(APP_ROOT_DIR_CONTEXT, "partners_documents")
+
 # --- Other Configurations (Add as needed) ---
 # Example:
 # API_KEY = "your_api_key_here"

--- a/partners/partner_dialog.py
+++ b/partners/partner_dialog.py
@@ -1,21 +1,49 @@
 # partners/partner_dialog.py
 from PyQt5.QtWidgets import (QDialog, QVBoxLayout, QFormLayout, QLineEdit, QPushButton,
                              QMessageBox, QDialogButtonBox, QGroupBox, QTableWidget,
-                             QTableWidgetItem, QHBoxLayout, QTextEdit, QListWidget, QListWidgetItem) # Added QListWidget, QListWidgetItem
-from PyQt5.QtCore import Qt
+                             QTableWidgetItem, QHBoxLayout, QTextEdit, QListWidget, QListWidgetItem,
+                             QTabWidget, QHeaderView, QAbstractItemView, QFileDialog, QDesktopServices, QInputDialog, QWidget) # Added QTabWidget and other necessary widgets
+from PyQt5.QtCore import Qt, QUrl
 import db.crud as db_manager
+import os
+import shutil
+from datetime import datetime
+
+# Try to import db_config for PARTNERS_DOCUMENTS_DIR, use fallback if not found
+try:
+    import db_config
+    PARTNERS_DOCUMENTS_BASE_DIR = db_config.PARTNERS_DOCUMENTS_DIR
+except ImportError:
+    PARTNERS_DOCUMENTS_BASE_DIR = 'partners_documents/' # Fallback directory
+    if not os.path.exists(PARTNERS_DOCUMENTS_BASE_DIR):
+        try:
+            os.makedirs(PARTNERS_DOCUMENTS_BASE_DIR, exist_ok=True)
+        except OSError as e:
+            # This is a fallback, so print an error and continue.
+            # The application might not function correctly for document storage.
+            print(f"Error creating fallback documents directory: {e}")
+
 
 class PartnerDialog(QDialog):
     def __init__(self, partner_id=None, parent=None):
         super().__init__(parent)
         self.partner_id = partner_id
         self.setWindowTitle(f"{'Edit' if partner_id else 'Add'} Partner")
-        self.setMinimumWidth(600) # Set a minimum width for the dialog
+        self.setMinimumWidth(700) # Increased width for tabs
+        self.setMinimumHeight(500)
 
-        self.original_contacts = [] # Store original contacts for diffing
-        self.deleted_contact_ids = set() # Store IDs of contacts marked for deletion
+        self.original_contacts = []
+        self.deleted_contact_ids = set()
 
-        layout = QVBoxLayout(self)
+        main_layout = QVBoxLayout(self)
+
+        # Tab Widget
+        self.tab_widget = QTabWidget()
+        main_layout.addWidget(self.tab_widget)
+
+        # --- Partner Details Tab ---
+        details_tab_widget = QWidget() # Create a new widget for the first tab's content
+        details_tab_layout = QVBoxLayout(details_tab_widget)
 
         # Partner Details Form
         details_group = QGroupBox("Partner Details")
@@ -30,57 +58,103 @@ class PartnerDialog(QDialog):
         form_layout.addRow("Address:", self.address_input)
         self.location_input = QLineEdit()
         form_layout.addRow("Location:", self.location_input)
-        self.notes_input = QTextEdit() # Changed to QTextEdit
-        self.notes_input.setFixedHeight(80) # Set a reasonable height
+        self.notes_input = QTextEdit()
+        self.notes_input.setFixedHeight(80)
         form_layout.addRow("Notes:", self.notes_input)
         details_group.setLayout(form_layout)
-        layout.addWidget(details_group)
+        details_tab_layout.addWidget(details_group)
 
         # Contacts Management
         contacts_group = QGroupBox("Contacts")
         contacts_layout = QVBoxLayout()
         self.contacts_table = QTableWidget()
-        self.contacts_table.setColumnCount(4) # Name, Email, Phone, Role
+        self.contacts_table.setColumnCount(4)
         self.contacts_table.setHorizontalHeaderLabels(["Name*", "Email", "Phone", "Role"])
-        # Make table headers resize correctly
         self.contacts_table.horizontalHeader().setStretchLastSection(True)
         contacts_layout.addWidget(self.contacts_table)
-
         contacts_buttons_layout = QHBoxLayout()
         self.add_contact_button = QPushButton("Add Contact")
         self.remove_contact_button = QPushButton("Remove Selected Contact")
         contacts_buttons_layout.addWidget(self.add_contact_button)
         contacts_buttons_layout.addWidget(self.remove_contact_button)
         contacts_layout.addLayout(contacts_buttons_layout)
-
         contacts_group.setLayout(contacts_layout)
-        layout.addWidget(contacts_group)
+        details_tab_layout.addWidget(contacts_group)
 
         # Categories Management
         categories_group = QGroupBox("Assign Categories")
         categories_layout = QVBoxLayout()
         self.categories_list_widget = QListWidget()
-        # self.categories_list_widget.setSelectionMode(QAbstractItemView.MultiSelection) # Not needed for checkable
         categories_layout.addWidget(self.categories_list_widget)
         categories_group.setLayout(categories_layout)
-        layout.addWidget(categories_group)
+        details_tab_layout.addWidget(categories_group)
 
+        details_tab_widget.setLayout(details_tab_layout) # Set the layout for the details tab widget
+        self.tab_widget.addTab(details_tab_widget, "Partner Details")
+
+        # --- Documents Tab ---
+        documents_tab_widget = QWidget()
+        documents_tab_layout = QVBoxLayout(documents_tab_widget)
+
+        self.documents_table = QTableWidget()
+        self.documents_table.setColumnCount(5) # document_id (hidden), Name, Type, Description, Date Added
+        self.documents_table.setHorizontalHeaderLabels(["ID", "Name", "Type", "Description", "Date Added"])
+        self.documents_table.setColumnHidden(0, True) # Hide document_id column
+        self.documents_table.horizontalHeader().setSectionResizeMode(1, QHeaderView.Stretch) # Name
+        self.documents_table.horizontalHeader().setSectionResizeMode(2, QHeaderView.ResizeToContents) # Type
+        self.documents_table.horizontalHeader().setSectionResizeMode(3, QHeaderView.Stretch) # Description
+        self.documents_table.horizontalHeader().setSectionResizeMode(4, QHeaderView.ResizeToContents) # Date
+        self.documents_table.setEditTriggers(QAbstractItemView.NoEditTriggers)
+        self.documents_table.setSelectionBehavior(QAbstractItemView.SelectRows)
+        self.documents_table.setSelectionMode(QAbstractItemView.SingleSelection)
+        documents_tab_layout.addWidget(self.documents_table)
+
+        doc_buttons_layout = QHBoxLayout()
+        self.upload_doc_button = QPushButton("Upload Document")
+        self.download_doc_button = QPushButton("Download Document")
+        self.delete_doc_button = QPushButton("Delete Document")
+        doc_buttons_layout.addWidget(self.upload_doc_button)
+        doc_buttons_layout.addWidget(self.download_doc_button)
+        doc_buttons_layout.addWidget(self.delete_doc_button)
+        documents_tab_layout.addLayout(doc_buttons_layout)
+
+        documents_tab_widget.setLayout(documents_tab_layout)
+        self.tab_widget.addTab(documents_tab_widget, "Documents")
+
+        # Dialog Buttons
         self.button_box = QDialogButtonBox(QDialogButtonBox.Save | QDialogButtonBox.Cancel)
-        layout.addWidget(self.button_box)
+        main_layout.addWidget(self.button_box)
 
         # Connect signals
         self.button_box.accepted.connect(self.accept_dialog)
         self.button_box.rejected.connect(self.reject)
         self.add_contact_button.clicked.connect(self.add_contact_row)
         self.remove_contact_button.clicked.connect(self.remove_contact_row)
+        self.upload_doc_button.clicked.connect(self.handle_upload_document)
+        self.download_doc_button.clicked.connect(self.handle_download_document)
+        self.delete_doc_button.clicked.connect(self.handle_delete_document)
 
         if self.partner_id:
-            self.load_partner_data()
+            self.load_partner_data() # This will also call load_partner_documents
             self.load_contacts()
-        self.load_and_set_partner_categories() # Load for both add and edit mode
+        else:
+            # New partner, disable document buttons until partner is saved
+            self.upload_doc_button.setEnabled(False)
+            self.download_doc_button.setEnabled(False)
+            self.delete_doc_button.setEnabled(False)
+            self.documents_table.setEnabled(False)
+
+        self.load_and_set_partner_categories()
 
     def load_partner_data(self):
-        if not self.partner_id: return
+        if not self.partner_id:
+            # Disable document buttons if it's a new partner (no ID yet)
+            self.upload_doc_button.setEnabled(False)
+            self.download_doc_button.setEnabled(False)
+            self.delete_doc_button.setEnabled(False)
+            self.documents_table.setEnabled(False)
+            return
+
         partner = db_manager.get_partner_by_id(self.partner_id)
         if partner:
             self.name_input.setText(partner.get('name', ''))
@@ -88,12 +162,221 @@ class PartnerDialog(QDialog):
             self.phone_input.setText(partner.get('phone', ''))
             self.address_input.setText(partner.get('address', ''))
             self.location_input.setText(partner.get('location', ''))
-            self.notes_input.setPlainText(partner.get('notes', '')) # Use setPlainText for QTextEdit
+            self.notes_input.setPlainText(partner.get('notes', ''))
+
+            # Enable document buttons as partner exists
+            self.upload_doc_button.setEnabled(True)
+            self.download_doc_button.setEnabled(True)
+            self.delete_doc_button.setEnabled(True)
+            self.documents_table.setEnabled(True)
+            self.load_partner_documents() # Load documents after partner data is loaded
+
+    def load_partner_documents(self):
+        if not self.partner_id:
+            self.documents_table.setRowCount(0)
+            return
+
+        self.documents_table.setRowCount(0) # Clear existing rows
+        documents = db_manager.get_documents_for_partner(self.partner_id)
+        if documents:
+            for doc in documents:
+                row_position = self.documents_table.rowCount()
+                self.documents_table.insertRow(row_position)
+
+                doc_id_item = QTableWidgetItem(doc.get('document_id'))
+                # Store file_path_relative in UserRole of the ID item for download/delete
+                doc_id_item.setData(Qt.UserRole, doc.get('file_path_relative'))
+
+                name_item = QTableWidgetItem(doc.get('document_name'))
+                type_item = QTableWidgetItem(doc.get('document_type'))
+                desc_item = QTableWidgetItem(doc.get('description'))
+
+                created_at_str = doc.get('created_at', '')
+                date_added_item = QTableWidgetItem(created_at_str)
+                try: # Try to parse and format date nicely
+                    dt_obj = datetime.fromisoformat(created_at_str.replace("Z", "+00:00"))
+                    date_added_item.setText(dt_obj.strftime('%Y-%m-%d %H:%M'))
+                except ValueError:
+                    pass # Keep original string if parsing fails
+
+                self.documents_table.setItem(row_position, 0, doc_id_item)
+                self.documents_table.setItem(row_position, 1, name_item)
+                self.documents_table.setItem(row_position, 2, type_item)
+                self.documents_table.setItem(row_position, 3, desc_item)
+                self.documents_table.setItem(row_position, 4, date_added_item)
+
+        # Enable/disable download/delete based on selection
+        self.documents_table.itemSelectionChanged.connect(self.update_document_button_states)
+        self.update_document_button_states()
+
+
+    def update_document_button_states(self):
+        has_selection = bool(self.documents_table.selectedItems())
+        # Upload button enabled if partner exists (handled in load_partner_data)
+        # self.upload_doc_button.setEnabled(bool(self.partner_id))
+        self.download_doc_button.setEnabled(has_selection and bool(self.partner_id))
+        self.delete_doc_button.setEnabled(has_selection and bool(self.partner_id))
+
+
+    def handle_upload_document(self):
+        if not self.partner_id:
+            QMessageBox.warning(self, "Partner Not Saved", "Please save the partner before uploading documents.")
+            return
+
+        file_path, _ = QFileDialog.getOpenFileName(self, "Select Document to Upload")
+        if not file_path:
+            return
+
+        original_filename = os.path.basename(file_path)
+
+        doc_type, ok = QInputDialog.getText(self, "Document Type", "Enter document type (e.g., Contract, Invoice):")
+        if not ok: # User cancelled
+            return
+        doc_type = doc_type.strip() if doc_type else "Other"
+
+
+        description, ok = QInputDialog.getText(self, "Document Description", "Enter an optional description:")
+        if not ok: # User cancelled
+             description = "" # Allow empty description if user cancels this specific dialog but not the overall upload
+        description = description.strip()
+
+
+        target_partner_dir = os.path.join(PARTNERS_DOCUMENTS_BASE_DIR, self.partner_id)
+        try:
+            os.makedirs(target_partner_dir, exist_ok=True)
+        except OSError as e:
+            QMessageBox.critical(self, "Directory Error", f"Could not create directory: {target_partner_dir}\n{e}")
+            return
+
+        # Ensure unique filename in target directory (simple append counter if exists)
+        # This is a basic approach. More robust would be UUID filenames or checking db for file_path_relative.
+        target_filename = original_filename
+        counter = 1
+        while os.path.exists(os.path.join(target_partner_dir, target_filename)):
+            name, ext = os.path.splitext(original_filename)
+            target_filename = f"{name}_{counter}{ext}"
+            counter += 1
+
+        target_file_path_full = os.path.join(target_partner_dir, target_filename)
+        file_path_relative_for_db = target_filename # Store only filename as relative path for this partner
+
+        try:
+            shutil.copy(file_path, target_file_path_full)
+        except IOError as e:
+            QMessageBox.critical(self, "File Error", f"Could not copy file: {e}")
+            return
+
+        doc_data = {
+            'partner_id': self.partner_id,
+            'document_name': original_filename, # Store original filename for display
+            'file_path_relative': file_path_relative_for_db, # Store potentially modified name used on disk
+            'document_type': doc_type,
+            'description': description
+        }
+
+        new_doc_id = db_manager.add_partner_document(doc_data)
+        if new_doc_id:
+            QMessageBox.information(self, "Success", "Document uploaded successfully.")
+            self.load_partner_documents()
+        else:
+            QMessageBox.critical(self, "Database Error", "Failed to record document in database.")
+            # Clean up copied file if DB record failed
+            if os.path.exists(target_file_path_full):
+                try:
+                    os.remove(target_file_path_full)
+                except OSError as e_remove:
+                    print(f"Error cleaning up file after DB failure: {e_remove}")
+
+
+    def handle_download_document(self):
+        selected_rows = self.documents_table.selectionModel().selectedRows()
+        if not selected_rows:
+            QMessageBox.warning(self, "No Document Selected", "Please select a document to download.")
+            return
+
+        selected_row = selected_rows[0].row()
+        doc_id_item = self.documents_table.item(selected_row, 0) # ID is in hidden column 0
+
+        if not doc_id_item: return # Should not happen if row is selected
+
+        file_path_relative = doc_id_item.data(Qt.UserRole)
+
+        if not file_path_relative:
+            QMessageBox.critical(self, "File Error", "File path not found for this document.")
+            return
+
+        full_path = os.path.join(PARTNERS_DOCUMENTS_BASE_DIR, self.partner_id, file_path_relative)
+
+        if os.path.exists(full_path):
+            # Ask user where to save the file
+            save_file_name, _ = QFileDialog.getSaveFileName(self, "Save Document As...", os.path.basename(full_path))
+            if save_file_name:
+                try:
+                    shutil.copy(full_path, save_file_name)
+                    QMessageBox.information(self, "Download Complete", f"File saved to: {save_file_name}")
+                    # Optionally open the folder containing the saved file
+                    # QDesktopServices.openUrl(QUrl.fromLocalFile(os.path.dirname(save_file_name)))
+                except shutil.Error as e:
+                    QMessageBox.critical(self, "Save Error", f"Could not save file: {e}")
+            # else: User cancelled SaveAs dialog
+        else:
+            QMessageBox.critical(self, "File Not Found", f"The document file could not be found at: {full_path}")
+
+
+    def handle_delete_document(self):
+        selected_rows = self.documents_table.selectionModel().selectedRows()
+        if not selected_rows:
+            QMessageBox.warning(self, "No Document Selected", "Please select a document to delete.")
+            return
+
+        selected_row = selected_rows[0].row()
+        doc_id_item = self.documents_table.item(selected_row, 0) # ID is in hidden column 0
+        doc_name_item = self.documents_table.item(selected_row, 1) # Name for confirmation
+
+        if not doc_id_item or not doc_name_item: return
+
+        document_id_to_delete = doc_id_item.text()
+        file_path_relative = doc_id_item.data(Qt.UserRole)
+        doc_name_for_confirm = doc_name_item.text()
+
+        reply = QMessageBox.question(self, "Confirm Deletion",
+                                     f"Are you sure you want to delete the document '{doc_name_for_confirm}'?",
+                                     QMessageBox.Yes | QMessageBox.No, QMessageBox.No)
+
+        if reply == QMessageBox.Yes:
+            full_file_path = os.path.join(PARTNERS_DOCUMENTS_BASE_DIR, self.partner_id, file_path_relative)
+
+            file_deleted_ok = False
+            if os.path.exists(full_file_path):
+                try:
+                    os.remove(full_file_path)
+                    file_deleted_ok = True
+                except OSError as e:
+                    QMessageBox.warning(self, "File Deletion Error", f"Could not delete file: {full_file_path}\n{e}")
+                    # Ask if user wants to proceed with DB deletion anyway
+                    proceed_reply = QMessageBox.question(self, "Database Deletion",
+                                                         "File deletion failed. Delete database record anyway?",
+                                                         QMessageBox.Yes | QMessageBox.No, QMessageBox.No)
+                    if proceed_reply == QMessageBox.No:
+                        return
+            else:
+                # File doesn't exist, maybe it was deleted manually. Still allow DB record deletion.
+                print(f"File not found for deletion: {full_file_path}. Proceeding with DB record deletion.")
+                file_deleted_ok = True # Consider it "ok" in terms of allowing DB delete
+
+            if file_deleted_ok: # If file deletion was successful OR file was not found (allowing DB cleanup)
+                if db_manager.delete_partner_document(document_id_to_delete):
+                    QMessageBox.information(self, "Success", "Document deleted successfully.")
+                    self.load_partner_documents()
+                else:
+                    QMessageBox.critical(self, "Database Error", "Failed to delete document record from database.")
+                    # Potentially re-copy file if DB delete failed? Or leave as is.
+
 
     def load_contacts(self):
-        if not self.partner_id: return # Only load if editing existing partner with contacts
+        if not self.partner_id: return
         self.original_contacts = db_manager.get_contacts_for_partner(self.partner_id)
-        self.contacts_table.setRowCount(0) # Clear existing rows
+        self.contacts_table.setRowCount(0)
         for contact in self.original_contacts:
             row_position = self.contacts_table.rowCount()
             self.contacts_table.insertRow(row_position)
@@ -173,19 +456,24 @@ class PartnerDialog(QDialog):
         else:
             new_partner_id = db_manager.add_partner(partner_data)
             if new_partner_id:
-                self.partner_id = new_partner_id # Important for saving new contacts
+                self.partner_id = new_partner_id
                 success = True
+                # Now that partner is saved, enable document controls
+                self.upload_doc_button.setEnabled(True)
+                # self.download_doc_button.setEnabled(False) # Will be enabled on selection
+                # self.delete_doc_button.setEnabled(False)  # Will be enabled on selection
+                self.documents_table.setEnabled(True)
+                self.load_partner_documents() # Load any (though unlikely) documents
             else:
                 QMessageBox.critical(self, "Database Error", "Failed to add new partner.")
-                return # Do not proceed to contacts if partner saving failed
+                return
 
-        if not success and self.partner_id: # update failed
+        if not success and self.partner_id:
              QMessageBox.critical(self, "Database Error", f"Failed to update partner {self.partner_id}.")
              return
 
-
         # Save Contacts
-        if self.partner_id: # Ensure partner_id is set (either existing or newly created)
+        if self.partner_id:
             current_contact_ids_in_table = set()
             for row in range(self.contacts_table.rowCount()):
                 name_item = self.contacts_table.item(row, 0)


### PR DESCRIPTION
This commit introduces document management capabilities for partners, allowing them to function more effectively as suppliers.

Key changes include:

1.  **Database Schema:**
    *   Added a `PartnerDocuments` table to store metadata about documents associated with partners.
    *   Includes columns for `document_id`, `partner_id`, `document_name`, `file_path_relative`, `document_type`, `description`, and timestamps.
    *   Added an index on `partner_id` in `PartnerDocuments`.

2.  **CRUD Operations:**
    *   Implemented new functions in `db/crud.py` for adding, retrieving, updating, and deleting partner documents.

3.  **Partner Dialog UI:**
    *   Enhanced `partners/partner_dialog.py` by adding a "Documents" tab.
    *   This tab allows you to:
        *   Upload documents for a specific partner.
        *   Download existing documents.
        *   Delete documents.
    *   Document files are stored in a configured directory (`partners_documents/[partner_id]/`).

4.  **Configuration:**
    *   Added `PARTNERS_DOCUMENTS_DIR` to `db_config.py` to specify the base storage location for partner documents.

5.  **Categorization:**
    *   Confirmed that partners can be categorized as "Supplier" using the existing category management tools.

This feature enables you to maintain a record of documents exchanged with suppliers, improving organization and traceability.