### PR TITLE
Fix: Resolve ImportError in html_editor

### DIFF
--- a/db/__init__.py
+++ b/db/__init__.py
@@ -1,0 +1,2 @@
+from .utils import get_document_context_data
+from .cruds.companies_crud import get_default_company


### PR DESCRIPTION
The html_editor.py module was attempting to import `get_document_context_data` and `get_default_company` directly from the `db` package. However, these functions were not exposed in `db/__init__.py`.

This commit updates `db/__init__.py` to import:
- `get_document_context_data` from `db.utils`
- `get_default_company` from `db.cruds.companies_crud`

This makes the functions available at the package level, resolving the ImportError encountered when running `main.py`.