### PR TITLE
Fix: Correct import path for initialize_database in main.py

### DIFF
--- a/main.py
+++ b/main.py
@@ -21,7 +21,7 @@ from PyQt5.QtWidgets import QDialog # Required for QDialog.Accepted check
 from db.db_seed import run_seed
 from db.cruds.companies_crud import get_all_companies, add_company # Specific imports for company check
 from db.cruds.application_settings_crud import get_setting # New import
-from db.ca import initialize_database # <<<< Initialize function moved to db/ca.py
+from db.init_schema import initialize_database # <<<< Initialize function moved to db/ca.py
 from auth.login_window import LoginWindow # Added for authentication
 from PyQt5.QtWidgets import QDialog # Required for QDialog.Accepted check (already present, but good to note)
 # from initial_setup_dialog import InitialSetupDialog # Redundant import, already imported above


### PR DESCRIPTION
The `initialize_database` function is located in `db/init_schema.py`, but `main.py` was attempting to import it from `db/ca.py`, which does not exist.

This change updates the import statement in `main.py` to correctly point to `db.init_schema.initialize_database`.