### PR TITLE
I've fixed the import for `get_predecessor_tasks` in the db module fo…

### DIFF
--- a/db/__init__.py
+++ b/db/__init__.py
@@ -268,6 +268,7 @@ from .cruds.tasks_crud import ( # Placeholders
     get_all_tasks,
     add_task_dependency,
     remove_task_dependency,
+    get_predecessor_tasks,
 )
 
 
@@ -477,7 +478,7 @@ __all__ = [
     # from status_settings_crud
     "get_status_setting_by_name", "get_status_setting_by_id", "get_all_status_settings",
     # from tasks_crud (placeholders)
-    "add_task", "get_task_by_id", "get_tasks_by_project_id", "update_task", "delete_task", "get_tasks_by_assignee_id", "get_all_tasks", "add_task_dependency", "remove_task_dependency",
+    "add_task", "get_task_by_id", "get_tasks_by_project_id", "update_task", "delete_task", "get_tasks_by_assignee_id", "get_all_tasks", "add_task_dependency", "remove_task_dependency", "get_predecessor_tasks",
 
     # KPIs
     "add_kpi_to_project", "get_kpis_for_project", "update_kpi", "delete_kpi", "add_kpi", "get_kpi_by_id", # Added get_kpi_by_id here too


### PR DESCRIPTION
…r you.

The function `get_predecessor_tasks` was defined in `db.cruds.tasks_crud` but wasn't being imported and exposed by the `db` facade in `db/__init__.py`.

I've updated `db/__init__.py` to:
1. Import `get_predecessor_tasks` from `.cruds.tasks_crud`.
2. Add `get_predecessor_tasks` to the `__all__` list.

This resolves the `ImportError` you were encountering in `projectManagement.py` when it tried to import `get_predecessor_tasks` from the `db` module.