### PR TITLE
Fix: Define and import get_tasks_by_project_id_ordered_by_sequence

### DIFF
--- a/db/__init__.py
+++ b/db/__init__.py
@@ -268,6 +268,8 @@ from .cruds.tasks_crud import ( # Placeholders
     get_all_tasks,
     add_task_dependency,
     remove_task_dependency,
+    get_predecessor_tasks,
+    get_tasks_by_project_id_ordered_by_sequence,
 )
 
 
@@ -477,7 +479,7 @@ __all__ = [
     # from status_settings_crud
     "get_status_setting_by_name", "get_status_setting_by_id", "get_all_status_settings",
     # from tasks_crud (placeholders)
-    "add_task", "get_task_by_id", "get_tasks_by_project_id", "update_task", "delete_task", "get_tasks_by_assignee_id", "get_all_tasks", "add_task_dependency", "remove_task_dependency",
+    "add_task", "get_task_by_id", "get_tasks_by_project_id", "update_task", "delete_task", "get_tasks_by_assignee_id", "get_all_tasks", "add_task_dependency", "remove_task_dependency", "get_predecessor_tasks", "get_tasks_by_project_id_ordered_by_sequence",
 
     # KPIs
     "add_kpi_to_project", "get_kpis_for_project", "update_kpi", "delete_kpi", "add_kpi", "get_kpi_by_id", # Added get_kpi_by_id here too

--- a/db/cruds/tasks_crud.py
+++ b/db/cruds/tasks_crud.py
@@ -52,3 +52,8 @@ def remove_task_dependency(predecessor_id, successor_id, db_session):
 # Add any other functions that might be imported from this module by other parts of the application
 # to prevent further import errors during broader testing, if known.
 # For now, only functions directly imported by document_manager_logic.py are added.
+
+def get_tasks_by_project_id_ordered_by_sequence(project_id):
+    print(f"Placeholder: get_tasks_by_project_id_ordered_by_sequence called with project_id={project_id}")
+    # Example: return db_session.query(Task).filter(Task.project_id == project_id).order_by(Task.sequence_order).all()
+    return []


### PR DESCRIPTION
The function `get_tasks_by_project_id_ordered_by_sequence` was being imported by `projectManagement.py` from the `db` module, but it was not defined in `db.cruds.tasks_crud.py` nor exported by `db/__init__.py`.

This commit:
1. Adds a placeholder definition for `get_tasks_by_project_id_ordered_by_sequence` in `db/cruds/tasks_crud.py`.
2. Updates `db/__init__.py` to import this function from `.cruds.tasks_crud`.
3. Adds the function to the `__all__` list in `db/__init__.py`.

This resolves the `ImportError` for
`get_tasks_by_project_id_ordered_by_sequence`.