### PR TITLE
Fix: Ensure MediaItems table is created before alteration

### DIFF
--- a/db/init_schema.py
+++ b/db/init_schema.py
@@ -1045,12 +1045,6 @@ def initialize_database():
         cursor.execute("DROP TABLE MediaItems_old_cat_mig")
         print("MediaItems 'category' migration complete, table recreated.")
     elif mi_needs_alter : # Table does not exist or exists but needs new columns (no category column)
-        if 'thumbnail_path' not in mi_columns :
-             cursor.execute("ALTER TABLE MediaItems ADD COLUMN thumbnail_path TEXT;")
-             print("Added 'thumbnail_path' column to MediaItems table.")
-        if 'metadata_json' not in mi_columns:
-             cursor.execute("ALTER TABLE MediaItems ADD COLUMN metadata_json TEXT;")
-             print("Added 'metadata_json' column to MediaItems table.")
         if not mi_columns: # Table does not exist, create it
             cursor.execute('''
                 CREATE TABLE MediaItems (
@@ -1061,6 +1055,12 @@ def initialize_database():
                     FOREIGN KEY (uploader_user_id) REFERENCES Users(user_id) ON DELETE SET NULL
                 );''')
             print("Created MediaItems table with new columns.")
+        if 'thumbnail_path' not in mi_columns :
+             cursor.execute("ALTER TABLE MediaItems ADD COLUMN thumbnail_path TEXT;")
+             print("Added 'thumbnail_path' column to MediaItems table.")
+        if 'metadata_json' not in mi_columns:
+             cursor.execute("ALTER TABLE MediaItems ADD COLUMN metadata_json TEXT;")
+             print("Added 'metadata_json' column to MediaItems table.")
 
     cursor.execute('''CREATE TABLE IF NOT EXISTS Tags (tag_id INTEGER PRIMARY KEY AUTOINCREMENT, tag_name TEXT NOT NULL UNIQUE);''')
     cursor.execute('''CREATE TABLE IF NOT EXISTS MediaItemTags (media_item_tag_id INTEGER PRIMARY KEY AUTOINCREMENT, media_item_id TEXT NOT NULL, tag_id INTEGER NOT NULL, FOREIGN KEY (media_item_id) REFERENCES MediaItems(media_item_id) ON DELETE CASCADE, FOREIGN KEY (tag_id) REFERENCES Tags(tag_id) ON DELETE CASCADE, UNIQUE (media_item_id, tag_id));''')


### PR DESCRIPTION
Moved the `CREATE TABLE MediaItems` statement to occur before any `ALTER TABLE MediaItems` statements within the initialization logic.

This resolves an `sqlite3.OperationalError: no such table: MediaItems` that would occur if the table didn't exist prior to the alteration attempt. The `PRAGMA table_info(MediaItems)` check would correctly indicate columns were missing (as the table itself was missing), leading to an attempt to alter a non-existent table.