### PR TITLE
Enable optional login with default user fallback and ensure module ac…

### DIFF
--- a/db/db_seed.py
+++ b/db/db_seed.py
@@ -152,6 +152,33 @@ def seed_initial_data(cursor: sqlite3.Cursor):
         else:
             logger.warning("Admin user ID not available, cannot seed admin team member.")
 
+        # Seed Default Operational User
+        DEFAULT_OPERATIONAL_USERNAME = "default_operational_user"
+        DEFAULT_OPERATIONAL_USER_ROLE = "User" # Assuming 'User' is a valid, less-privileged role
+
+        logger.info(f"Checking for default operational user '{DEFAULT_OPERATIONAL_USERNAME}'...")
+        existing_operational_user = users_crud_instance.get_user_by_username(DEFAULT_OPERATIONAL_USERNAME, conn=conn)
+
+        if existing_operational_user is None:
+            logger.info(f"Default operational user '{DEFAULT_OPERATIONAL_USERNAME}' not found. Creating...")
+            operational_user_data = {
+                'username': DEFAULT_OPERATIONAL_USERNAME,
+                'password': uuid.uuid4().hex, # Secure random password
+                'email': f"{DEFAULT_OPERATIONAL_USERNAME}@example.local", # Unique placeholder email
+                'role': DEFAULT_OPERATIONAL_USER_ROLE,
+                'full_name': "Default Operational User",
+                'is_active': True
+            }
+            try:
+                op_user_result = users_crud_instance.add_user(operational_user_data, conn=conn)
+                if op_user_result['success']:
+                    logger.info(f"Successfully created default operational user '{DEFAULT_OPERATIONAL_USERNAME}' with ID: {op_user_result['user_id']}.")
+                else:
+                    logger.error(f"Failed to create default operational user '{DEFAULT_OPERATIONAL_USERNAME}'. Error: {op_user_result.get('error', 'Unknown error')}")
+            except Exception as e_op_user:
+                logger.error(f"Exception during creation of default operational user '{DEFAULT_OPERATIONAL_USERNAME}': {e_op_user}", exc_info=True)
+        else:
+            logger.info(f"Default operational user '{DEFAULT_OPERATIONAL_USERNAME}' already exists with ID: {existing_operational_user['user_id']}. Skipping creation.")
 
         # 5. Countries
         logger.info("Seeding default countries...")

--- a/document_manager_logic.py
+++ b/document_manager_logic.py
@@ -120,7 +120,7 @@ def handle_create_client_execution(doc_manager, client_data_dict=None):
         'status_id': default_status_id,
         'category': 'Standard',
         'notes': '',
-        'created_by_user_id': "system_user_placeholder_001" # Added placeholder
+        'created_by_user_id': doc_manager.current_user_id
     }
 
     actual_new_client_id = None

--- a/main_window.py
+++ b/main_window.py
@@ -142,9 +142,10 @@ class SettingsDialog(OriginalSettingsDialog):
     def update_forwarder_button_states(self): en=bool(self.forwarders_table.selectedItems()); self.edit_forwarder_btn.setEnabled(en); self.delete_forwarder_btn.setEnabled(en)
 
 class DocumentManager(QMainWindow):
-    def __init__(self, app_root_dir):
+    def __init__(self, app_root_dir, current_user_id):
         super().__init__()
         self.app_root_dir = app_root_dir
+        self.current_user_id = current_user_id
         self.setWindowTitle(self.tr("Gestionnaire de Documents Client")); self.setGeometry(100, 100, 1200, 800)
         self.setWindowIcon(QIcon.fromTheme("folder-documents"))
         
@@ -265,15 +266,17 @@ class DocumentManager(QMainWindow):
         self.product_equivalency_action = QAction(QIcon.fromTheme("document-properties", QIcon(":/icons/modern/link.svg")), self.tr("Gérer Équivalences Produits"), self); self.product_equivalency_action.triggered.connect(self.open_product_equivalency_dialog)
         self.product_list_action = QAction(QIcon(":/icons/book.svg"), self.tr("Product List"), self); self.product_list_action.triggered.connect(self.open_product_list_placeholder)
         self.partner_management_action = QAction(QIcon(":/icons/team.svg"), self.tr("Partner Management"), self); self.partner_management_action.triggered.connect(self.show_partner_management_view)
+        self.statistics_action = QAction(QIcon(":/icons/bar-chart.svg"), self.tr("Statistiques"), self); self.statistics_action.triggered.connect(self.show_statistics_view)
 
     def create_menus_main(self): 
         menu_bar = self.menuBar(); file_menu = menu_bar.addMenu(self.tr("Fichier")); file_menu.addAction(self.settings_action); file_menu.addAction(self.template_action); file_menu.addAction(self.status_action); file_menu.addAction(self.product_equivalency_action); file_menu.addSeparator(); file_menu.addAction(self.exit_action)
-        modules_menu = menu_bar.addMenu(self.tr("Modules")); modules_menu.addAction(self.documents_view_action); modules_menu.addAction(self.project_management_action); modules_menu.addAction(self.product_list_action); modules_menu.addAction(self.partner_management_action)
+        modules_menu = menu_bar.addMenu(self.tr("Modules")); modules_menu.addAction(self.documents_view_action); modules_menu.addAction(self.project_management_action); modules_menu.addAction(self.product_list_action); modules_menu.addAction(self.partner_management_action); modules_menu.addAction(self.statistics_action)
         help_menu = menu_bar.addMenu(self.tr("Aide")); about_action = QAction(QIcon(":/icons/help-circle.svg"), self.tr("À propos"), self); about_action.triggered.connect(self.show_about_dialog); help_menu.addAction(about_action)
 
     def show_project_management_view(self): self.main_area_stack.setCurrentWidget(self.project_management_widget_instance)
     def show_documents_view(self): self.main_area_stack.setCurrentWidget(self.documents_page_widget)
     def show_partner_management_view(self): self.main_area_stack.setCurrentWidget(self.partner_management_widget_instance)
+    def show_statistics_view(self): self.main_area_stack.setCurrentWidget(self.statistics_dashboard_instance)
     def show_about_dialog(self): QMessageBox.about(self, self.tr("À propos"), self.tr("<b>Gestionnaire de Documents Client</b><br><br>Version 4.0<br>Application de gestion de documents clients avec templates Excel.<br><br>Développé par Saadiya Management (Concept)"))
         
     def execute_create_client_slot(self, client_data_dict=None):


### PR DESCRIPTION
…cess

This commit implements changes to allow your application to operate without a mandatory user login. If you cancel the login prompt, the application now falls back to a predefined 'default_operational_user'.

Key changes:
- Modified `db/db_seed.py` to create 'default_operational_user' during the seeding process if it doesn't already exist. This user is assigned the 'User' role.
- Updated `main.py` to alter the authentication flow. If login is not completed, the application now loads the context of 'default_operational_user' instead of exiting. A critical error is displayed if the default user cannot be found.
- Ensured that `main.CURRENT_USER_ID` (which can be the actual logged-in user or the default user) is correctly passed to `DocumentManager` and used in `document_manager_logic.py` when setting `created_by_user_id` for new clients.
- Added a menu action for the 'Statistiques' module in `main_window.py`.
- Verified that other existing modules also have accessible menu actions.

The application now provides immediate usability with a default context, while still allowing you to log in to your specific accounts.