### PR TITLE
Fix: Resolve ImportError for DATABASE_NAME in client_widget

### DIFF
--- a/db/__init__.py
+++ b/db/__init__.py
@@ -1,3 +1,20 @@
+import sys
+import os
+
+# Temporarily add the parent directory to sys.path to allow importing from config.py
+parent_dir = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
+if parent_dir not in sys.path:
+    sys.path.insert(0, parent_dir)
+
+try:
+    from config import DATABASE_PATH
+finally:
+    # Remove the parent directory from sys.path
+    if parent_dir in sys.path:
+        sys.path.remove(parent_dir)
+
+DATABASE_NAME = DATABASE_PATH
+
 from .cruds.status_settings_crud import (
     get_status_setting_by_id,
     get_all_status_settings,
@@ -134,6 +151,7 @@ from .cruds.application_settings_crud import get_setting, set_setting
 from .init_schema import initialize_database
 
 __all__ = [
+    "DATABASE_NAME",
     "get_setting",
     "set_setting",
     "get_status_setting_by_id",


### PR DESCRIPTION
The client_widget.py module was attempting to import DATABASE_NAME from the db package, but this name was not defined in db/__init__.py.

This change modifies db/__init__.py to:
1. Import DATABASE_PATH from the root config.py file.
2. Alias DATABASE_PATH as DATABASE_NAME.
3. Add DATABASE_NAME to the __all__ list, making it available for import.

This resolves the ImportError and allows client_widget.py to access the database path as intended.