### PR TITLE
Fix: Resolve errors in 'Parametre' section for transporters and freig…

### DIFF
--- a/db/__init__.py
+++ b/db/__init__.py
@@ -171,6 +171,8 @@ from .cruds.partners_crud import (
     get_partner_category_by_id, # Added
 )
 from .cruds.locations_crud import get_all_countries, add_country, get_or_add_country, get_all_cities, add_city, get_or_add_city, get_country_by_id, get_city_by_id
+from .cruds.transporters_crud import get_all_transporters, add_transporter, get_transporter_by_id, update_transporter, delete_transporter
+from .cruds.freight_forwarders_crud import get_all_freight_forwarders, add_freight_forwarder, get_freight_forwarder_by_id, update_freight_forwarder, delete_freight_forwarder
 from .cruds.application_settings_crud import get_setting, set_setting
 from .init_schema import initialize_database
 
@@ -314,4 +316,14 @@ __all__ = [
     "initialize_database",
     "get_setting",
     "set_setting",
+    "get_all_transporters",
+    "add_transporter",
+    "get_transporter_by_id",
+    "update_transporter",
+    "delete_transporter",
+    "get_all_freight_forwarders",
+    "add_freight_forwarder",
+    "get_freight_forwarder_by_id",
+    "update_freight_forwarder",
+    "delete_freight_forwarder",
 ]

--- a/main_window.py
+++ b/main_window.py
@@ -103,7 +103,7 @@ class SettingsDialog(OriginalSettingsDialog):
     def load_transporters_table(self):
         self.transporters_table.setRowCount(0); self.transporters_table.setSortingEnabled(False)
         try:
-            for r, t in enumerate(get_all_transporters() or []):
+            for r, t in enumerate(db_manager.get_all_transporters() or []):
                 self.transporters_table.insertRow(r)
                 id_item = QTableWidgetItem(t.get('transporter_id')); self.transporters_table.setItem(r,0,id_item)
                 name_item = QTableWidgetItem(t.get('name')); name_item.setData(Qt.UserRole, t.get('transporter_id')); self.transporters_table.setItem(r,1,name_item)
@@ -120,12 +120,12 @@ class SettingsDialog(OriginalSettingsDialog):
         if not self.transporters_table.selectedItems(): return
         t_id=self.transporters_table.item(self.transporters_table.currentRow(),0).text()
         if QMessageBox.question(self,self.tr("Confirmer Suppression"),self.tr("Supprimer ce transporteur?"),QMessageBox.Yes|QMessageBox.No,QMessageBox.No)==QMessageBox.Yes and db_manager.delete_transporter(t_id): self.load_transporters_table()
-        else: QMessageBox.warning(self,self.tr("Erreur DB"),self.tr("Impossible de supprimer."))
+        else: QMessageBox.warning(self,self.tr("Erreur DB"),self.tr("Impossible de supprimer le transporteur."))
     def update_transporter_button_states(self): en=bool(self.transporters_table.selectedItems()); self.edit_transporter_btn.setEnabled(en); self.delete_transporter_btn.setEnabled(en)
     def load_forwarders_table(self):
         self.forwarders_table.setRowCount(0); self.forwarders_table.setSortingEnabled(False)
         try:
-            for r,f in enumerate(get_all_freight_forwarders() or []):
+            for r,f in enumerate(db_manager.get_all_freight_forwarders() or []):
                 self.forwarders_table.insertRow(r)
                 id_item=QTableWidgetItem(f.get('forwarder_id')); self.forwarders_table.setItem(r,0,id_item)
                 name_item=QTableWidgetItem(f.get('name')); name_item.setData(Qt.UserRole,f.get('forwarder_id')); self.forwarders_table.setItem(r,1,name_item)
@@ -142,7 +142,7 @@ class SettingsDialog(OriginalSettingsDialog):
         if not self.forwarders_table.selectedItems(): return
         f_id=self.forwarders_table.item(self.forwarders_table.currentRow(),0).text()
         if QMessageBox.question(self,self.tr("Confirmer Suppression"),self.tr("Supprimer ce transitaire?"),QMessageBox.Yes|QMessageBox.No,QMessageBox.No)==QMessageBox.Yes and db_manager.delete_freight_forwarder(f_id): self.load_forwarders_table()
-        else: QMessageBox.warning(self,self.tr("Erreur DB"),self.tr("Impossible de supprimer."))
+        else: QMessageBox.warning(self,self.tr("Erreur DB"),self.tr("Impossible de supprimer le transitaire."))
     def update_forwarder_button_states(self): en=bool(self.forwarders_table.selectedItems()); self.edit_forwarder_btn.setEnabled(en); self.delete_forwarder_btn.setEnabled(en)
 
 class DocumentManager(QMainWindow):


### PR DESCRIPTION
…ht forwarders

This commit addresses several errors that prevented the management of transporters and freight forwarders in the application's settings:

1.  **Corrected DB Function Exposure:**
    - Modified `db/__init__.py` to properly import and expose `get_all_transporters`, `add_transporter`, `get_transporter_by_id`, `update_transporter`, `delete_transporter` from the transporters_crud module.
    - Similarly, exposed `get_all_freight_forwarders`, `add_freight_forwarder`, `get_freight_forwarder_by_id`, `update_freight_forwarder`, `delete_freight_forwarder` from the freight_forwarders_crud module.
    - This resolves the `AttributeError: module 'db' has no attribute 'add_freight_forwarder'` and similar issues for other CRUD functions.

2.  **Corrected UI DB Calls:**
    - Updated `main_window.py` in the `SettingsDialog` to use `db_manager.get_all_transporters()` and `db_manager.get_all_freight_forwarders()` when loading table data.
    - This resolves the `NameError`s for these functions.

3.  **Verified Dialog Logic:**
    - Confirmed that `TransporterDialog` and `FreightForwarderDialog` in `dialogs.py` already correctly use the `db_manager` alias for their add/update operations.

4.  **Refined Deletion Error Messages:**
    - Slightly improved the user feedback in `SettingsDialog` when deleting a transporter or freight forwarder fails, making the message more specific (e.g., "Impossible de supprimer le transporteur.").

With these changes, the loading, adding, editing, and deleting functionalities for transporters and freight forwarders in the "Parametre" section should now work as intended.