### PR TITLE
Fix: Resolve ImportError for tasks_crud functions

### DIFF
--- a/db/__init__.py
+++ b/db/__init__.py
@@ -43,10 +43,6 @@ from .cruds.tasks_crud import (
     delete_task,
     get_task_by_id,
     get_tasks_by_assignee_id,
-    get_predecessor_tasks,
-    add_task_dependency,
-    remove_task_dependency,
-    get_tasks_by_project_id_ordered_by_sequence,
 )
 from .cruds.kpis_crud import get_kpis_for_project
 from .cruds.activity_logs_crud import add_activity_log, get_activity_logs
@@ -207,10 +203,6 @@ __all__ = [
     "delete_task",
     "get_task_by_id",
     "get_tasks_by_assignee_id",
-    "get_predecessor_tasks",
-    "add_task_dependency",
-    "remove_task_dependency",
-    "get_tasks_by_project_id_ordered_by_sequence",
     "get_kpis_for_project",
     "add_activity_log",
     "get_activity_logs",


### PR DESCRIPTION
I've removed imports of non-existent functions from db.cruds.tasks_crud within db/__init__.py. The functions get_predecessor_tasks, add_task_dependency, remove_task_dependency, and
get_tasks_by_project_id_ordered_by_sequence were being imported in db/__init__.py but were not implemented in db/cruds/tasks_crud.py.

This change removes these imports and also ensures they are not listed in the __all__ export list of db/__init__.py, resolving the ImportError that occurred at application startup.