### PR TITLE
Fix: Improve template category loading and error handling

### DIFF
--- a/db/cruds/template_categories_crud.py
+++ b/db/cruds/template_categories_crud.py
@@ -52,10 +52,12 @@ def get_template_category_by_name(category_name: str, conn: sqlite3.Connection =
 
 @_manage_conn
 def get_all_template_categories(conn: sqlite3.Connection = None) -> list[dict]:
+    logging.info("Attempting to fetch all template categories.")
     cursor = conn.cursor()
     try:
         cursor.execute("SELECT * FROM TemplateCategories ORDER BY category_name")
         rows = cursor.fetchall()
+        logging.info(f"Found {len(rows)} template categories.")
         return [dict(row) for row in rows]
     except sqlite3.Error as e:
         logging.error(f"Failed to get all template categories: {e}")

--- a/dialogs.py
+++ b/dialogs.py
@@ -518,12 +518,27 @@ class TemplateDialog(QDialog):
         self.category_filter_combo.addItem(self.tr("All Categories"), "all")
         try:
             categories = get_all_template_categories()
-            if categories:
-                for category in categories:
-                    self.category_filter_combo.addItem(category['category_name'], category['category_id'])
+            if not categories:
+                logging.critical("TemplateDialog: populate_category_filter: No template categories found in the database. This is unexpected as categories should be seeded. Check database initialization and seeding process.")
+                QMessageBox.critical(self, self.tr("Critical Error"),
+                                     self.tr("No template categories could be loaded. This is essential for managing templates. Please check the application logs and ensure the database is correctly initialized. The template management dialog may not function correctly."))
+                self.category_filter_combo.setEnabled(False)
+                # Consider disabling other parts of the dialog or preventing full display
+                return # Stop further processing in this method
+
+            # If categories were found (even if it's an empty list, though 'if not categories' handles that)
+            # The original 'if categories:' check is slightly redundant now but harmless.
+            for category in categories: # This loop won't run if categories is empty or None
+                self.category_filter_combo.addItem(category['category_name'], category['category_id'])
+
         except Exception as e:
-            print(f"Error populating category filter: {e}") # Log error
-            QMessageBox.warning(self, self.tr("Filter Error"), self.tr("Could not load template categories for filtering."))
+            # This block now specifically handles errors during the fetching process itself,
+            # not the case of "successfully fetched but no categories".
+            logging.error(f"TemplateDialog: populate_category_filter: Failed to load template categories: {e}")
+            QMessageBox.warning(self, self.tr("Filter Error"),
+                                self.tr("An error occurred while trying to load template categories for filtering. Please check logs for details."))
+            # Optionally, disable the combo here too, or let it be usable if some categories were added before exception.
+            # self.category_filter_combo.setEnabled(False)
 
     def populate_language_filter(self):
         self.language_filter_combo.addItem(self.tr("All Languages"), "all")


### PR DESCRIPTION
Enhanced logging in `get_all_template_categories` to provide better diagnostics during template category fetching.

Improved error handling in `TemplateDialog`'s `populate_category_filter` method:
- Logs a critical error if no template categories are returned from the database.
- Displays a more specific error message to you.
- Disables the category filter combo box if categories cannot be loaded.

Verified that `TemplateDialog` is instantiated on your action, not prematurely at startup, ensuring database initialization precedes its data loading requirements.

These changes aim to address a potential 'Could not load categories for filter: category_id' error that might occur if template category data is not available when the TemplateDialog is initialized, particularly in first-run scenarios.