### PR TITLE
Fix: Resolve AttributeError for db.get_all_products

### DIFF
--- a/db/__init__.py
+++ b/db/__init__.py
@@ -44,7 +44,7 @@ from .cruds.projects_crud import (
     get_total_projects_count, # Added
     get_active_projects_count, # Added
 )
-from .cruds.products_crud import get_total_products_count # Added
+from .cruds.products_crud import get_total_products_count, get_all_products # Added
 from .cruds.tasks_crud import (
     get_tasks_by_project_id,
     add_task,
@@ -221,6 +221,7 @@ __all__ = [
     "delete_client_document_note",
     "get_client_document_note_by_id",
     "get_document_context_data",
+    "get_all_products", # Added
     "get_all_projects",
     "get_project_by_id",
     "add_project",

--- a/dialogs/send_email_dialog.py
+++ b/dialogs/send_email_dialog.py
@@ -15,7 +15,7 @@ from PyQt5.QtCore import Qt # Included for safety and common Qt enum usage
 
 import db as db_manager
 from db.cruds.clients_crud import clients_crud_instance
-from db.cruds.templates_crud import templates_crud_instance
+from db.cruds import templates_crud
 
 # Anticipated imports for other dialogs
 from .select_contacts_dialog import SelectContactsDialog
@@ -165,7 +165,7 @@ class SendEmailDialog(QDialog):
         try:
             all_templates_for_lang = []
             for template_type in self.email_template_types:
-                templates = templates_crud_instance.get_templates_by_type_and_language(
+                templates = templates_crud.get_templates_by_type(
                     template_type=template_type, language_code=language_code
                 )
                 if templates: all_templates_for_lang.extend(templates)


### PR DESCRIPTION
The function `get_all_products` was defined in `db.cruds.products_crud` but not exposed in the top-level `db` package's `__init__.py`. This caused an `AttributeError: module 'db' has no attribute 'get_all_products'` when called from other parts of the application.

This commit updates `db/__init__.py` to import and add `get_all_products` from `db.cruds.products_crud` to its `__all__` list, making it available as `db.get_all_products()`.