### PR TITLE
Fix: Correct database schema and resolve category loading errors

### DIFF
--- a/db/__init__.py
+++ b/db/__init__.py
@@ -44,7 +44,7 @@ from .cruds.projects_crud import (
     get_total_projects_count, # Added
     get_active_projects_count, # Added
 )
-from .cruds.products_crud import get_total_products_count # Added
+from .cruds.products_crud import get_total_products_count, get_all_products # Added
 from .cruds.tasks_crud import (
     get_tasks_by_project_id,
     add_task,
@@ -221,6 +221,7 @@ __all__ = [
     "delete_client_document_note",
     "get_client_document_note_by_id",
     "get_document_context_data",
+    "get_all_products", # Added
     "get_all_projects",
     "get_project_by_id",
     "add_project",

--- a/db/init_schema.py
+++ b/db/init_schema.py
@@ -117,6 +117,33 @@ def initialize_database():
     )
     """)
 
+    # Ensure salt, is_deleted, and deleted_at columns exist in Users table
+    cursor.execute("PRAGMA table_info(Users)")
+    users_columns_info = cursor.fetchall()
+    users_column_names = [info['name'] for info in users_columns_info]
+
+    if 'salt' not in users_column_names:
+        try:
+            # Using a temporary default for NOT NULL. Real salting should occur on user creation/update.
+            cursor.execute("ALTER TABLE Users ADD COLUMN salt TEXT NOT NULL DEFAULT 'tempsalt'")
+            print("Added 'salt' column to Users table with a temporary default.")
+        except sqlite3.Error as e_alter_salt:
+            print(f"Error adding 'salt' column to Users table: {e_alter_salt}")
+
+    if 'is_deleted' not in users_column_names:
+        try:
+            cursor.execute("ALTER TABLE Users ADD COLUMN is_deleted INTEGER DEFAULT 0")
+            print("Added 'is_deleted' column to Users table.")
+        except sqlite3.Error as e_alter_is_deleted:
+            print(f"Error adding 'is_deleted' column to Users table: {e_alter_is_deleted}")
+
+    if 'deleted_at' not in users_column_names:
+        try:
+            cursor.execute("ALTER TABLE Users ADD COLUMN deleted_at TEXT")
+            print("Added 'deleted_at' column to Users table.")
+        except sqlite3.Error as e_alter_deleted_at:
+            print(f"Error adding 'deleted_at' column to Users table: {e_alter_deleted_at}")
+
     # Create Companies table (base from ca.py)
     cursor.execute("""
     CREATE TABLE IF NOT EXISTS Companies (
@@ -509,6 +536,25 @@ def initialize_database():
         UNIQUE (product_name, language_code)
     )
     """)
+
+    # Ensure is_deleted and deleted_at columns exist for soft delete in Products table
+    cursor.execute("PRAGMA table_info(Products)")
+    products_columns_info = cursor.fetchall()
+    products_column_names = [info['name'] for info in products_columns_info]
+
+    if 'is_deleted' not in products_column_names:
+        try:
+            cursor.execute("ALTER TABLE Products ADD COLUMN is_deleted INTEGER DEFAULT 0")
+            print("Added 'is_deleted' column to Products table.")
+        except sqlite3.Error as e_alter_is_deleted_prod:
+            print(f"Error adding 'is_deleted' column to Products table: {e_alter_is_deleted_prod}")
+
+    if 'deleted_at' not in products_column_names:
+        try:
+            cursor.execute("ALTER TABLE Products ADD COLUMN deleted_at TEXT")
+            print("Added 'deleted_at' column to Products table.")
+        except sqlite3.Error as e_alter_deleted_at_prod:
+            print(f"Error adding 'deleted_at' column to Products table: {e_alter_deleted_at_prod}")
 
     # Create ProductDimensions table (from ca.py)
     cursor.execute("""

--- a/dialogs/send_email_dialog.py
+++ b/dialogs/send_email_dialog.py
@@ -15,7 +15,7 @@ from PyQt5.QtCore import Qt # Included for safety and common Qt enum usage
 
 import db as db_manager
 from db.cruds.clients_crud import clients_crud_instance
-from db.cruds.templates_crud import templates_crud_instance
+from db.cruds import templates_crud
 
 # Anticipated imports for other dialogs
 from .select_contacts_dialog import SelectContactsDialog
@@ -165,7 +165,7 @@ class SendEmailDialog(QDialog):
         try:
             all_templates_for_lang = []
             for template_type in self.email_template_types:
-                templates = templates_crud_instance.get_templates_by_type_and_language(
+                templates = templates_crud.get_templates_by_type(
                     template_type=template_type, language_code=language_code
                 )
                 if templates: all_templates_for_lang.extend(templates)


### PR DESCRIPTION
This commit addresses several database issues:

1.  Adds missing `ALTER TABLE` statements to `db/init_schema.py` for:
    *   `Users.salt`
    *   `Users.is_deleted`
    *   `Users.deleted_at`
    *   `Products.is_deleted`
    *   `Products.deleted_at`
    This ensures that these columns are added to existing databases if they
    were created with an older schema, resolving "no such column" errors
    during application startup and data seeding.

2.  The correction of these schema errors is expected to allow the database seeding process in `db/db_seed.py` to complete successfully without transaction rollbacks. This, in turn, should ensure that template categories (e.g., "Modèles Email SAV") are properly created when default templates are seeded.

3.  Resolves the "Could not load categories for filter: 'category_id'" error in the Template Management dialog, as categories should now be correctly seeded and available for loading into the filter controls.