### PR TITLE
Fix: Address multiple runtime, database, and icon errors

### DIFF
--- a/client_widget.py
+++ b/client_widget.py
@@ -22,6 +22,7 @@ from PyQt5.QtWidgets import QListWidgetItem
 from PyQt5.QtGui import QPixmap
 
 import db as db_manager
+from db.cruds.clients_crud import clients_crud_instance
 from excel_editor import ExcelEditor
 from html_editor import HtmlEditor
 from dialogs import ClientProductDimensionDialog, AssignPersonnelDialog, AssignTransporterDialog, AssignFreightForwarderDialog # Added import
@@ -181,9 +182,9 @@ class ClientWidget(QWidget):
         self.category_value_label = QLabel(self.client_info.get("category", self.tr("N/A")))
 
         # Initialize distributor specific info labels (used in populate_details_layout)
-        self.distributor_info_label = QLabel(self.tr("Info Distributeur:"))
-        self.distributor_info_value_label = QLabel(self.client_info.get('distributor_specific_info', ''))
-        self.distributor_info_value_label.setWordWrap(True)
+        # self.distributor_info_label = QLabel(self.tr("Info Distributeur:"))
+        # self.distributor_info_value_label = QLabel(self.client_info.get('distributor_specific_info', ''))
+        # self.distributor_info_value_label.setWordWrap(True)
 
 
         self.populate_details_layout() # Builds the details_layout
@@ -1696,6 +1697,11 @@ class ClientWidget(QWidget):
         self.detail_value_labels["category_value"] = self.category_value_label # Store for edit mode
 
         # Distributor Specific Info (conditionally visible)
+        self.distributor_info_label = QLabel(self.tr("Info Distributeur:"))
+        self.distributor_info_value_label = QLabel(self.client_info.get('distributor_specific_info', ''))
+        self.distributor_info_value_label.setWordWrap(True)
+        self.distributor_info_value_label.setObjectName("distributorInfoValueLabel") # Keep object name if used in QSS
+        self.distributor_info_label.setObjectName("distributorInfoLabel")
         self.details_layout.addRow(self.distributor_info_label, self.distributor_info_value_label)
         self.toggle_distributor_info_visibility() # Call to set initial visibility
 
@@ -2877,7 +2883,7 @@ class ClientWidget(QWidget):
             # Update self.client_info with all new values, including text names for country/city/status
             # This ensures the display view (populate_details_layout) has the most current data
             # A full fetch might be cleaner:
-            updated_client_full_info = db_manager.get_client_by_id(self.client_info['client_id'])
+            updated_client_full_info = clients_crud_instance.get_client_by_id(self.client_info['client_id'])
             if updated_client_full_info:
                 self.client_info = updated_client_full_info # Replace local client_info
 

--- a/db/__init__.py
+++ b/db/__init__.py
@@ -114,7 +114,8 @@ from .cruds.templates_crud import ( # Modified
     get_all_file_based_templates,
     get_distinct_template_languages,
     get_distinct_template_types,
-    get_filtered_templates
+    get_filtered_templates,
+    get_distinct_languages_for_template_type
 )
 from .cruds.cover_page_templates_crud import get_cover_page_template_by_id
 from .cruds.milestones_crud import (
@@ -287,6 +288,7 @@ __all__ = [
     "get_all_file_based_templates", # From templates_crud
     "get_distinct_template_languages", # Added from templates_crud.py
     "get_distinct_template_types", # Added from templates_crud.py
+    "get_distinct_languages_for_template_type", # Added this line
     "get_filtered_templates", # Added from templates_crud.py
     "get_cover_page_template_by_id", # Now from cover_page_templates_crud
     "get_milestones_for_project",

--- a/db/init_schema.py
+++ b/db/init_schema.py
@@ -601,6 +601,19 @@ def initialize_database():
     )
     """)
 
+    # Ensure serial_number column exists in ClientProjectProducts table
+    cursor.execute("PRAGMA table_info(ClientProjectProducts)")
+    cpp_columns_info_check = cursor.fetchall() # Use a different variable name to avoid conflict
+    cpp_column_names_check = [info['name'] for info in cpp_columns_info_check]
+
+    if 'serial_number' not in cpp_column_names_check:
+        try:
+            cursor.execute("ALTER TABLE ClientProjectProducts ADD COLUMN serial_number TEXT")
+            print("Added 'serial_number' column to ClientProjectProducts table.")
+        except sqlite3.Error as e_alter_cpp_sn:
+            print(f"Error adding 'serial_number' column to ClientProjectProducts table: {e_alter_cpp_sn}")
+    # The existing check for purchase_confirmed_at can remain as is.
+
     # Ensure purchase_confirmed_at column exists in ClientProjectProducts table
     cursor.execute("PRAGMA table_info(ClientProjectProducts)")
     cpp_columns_info = cursor.fetchall()

--- a/icons.qrc
+++ b/icons.qrc
@@ -5,6 +5,8 @@
     <file alias="pencil.svg">icons/pencil.svg</file>
     <file alias="trash.svg">icons/trash.svg</file>
     <file alias="plus.svg">icons/plus.svg</file>
+    <file alias="dialog-cancel.svg">icons/x.svg</file>
+    <file alias="dialog-ok-apply.svg">icons/check.svg</file>
     <file alias="chevron-up.svg">icons/chevron-up.svg</file>
     <file alias="chevron-down.svg">icons/chevron-down.svg</file>
     <file alias="check.svg">icons/check.svg</file>


### PR DESCRIPTION
This commit resolves several issues identified from error tracebacks:

1.  **RuntimeError for QLabel in client_widget.py:** Ensured `distributor_info_label` and `distributor_info_value_label` are valid by re-initializing them within `populate_details_layout`. This prevents errors from using potentially deleted C++ QLabel objects during UI refreshes.

2.  **AttributeError for db.get_client_by_id in client_widget.py:** Corrected the call to use `clients_crud_instance.get_client_by_id` and added the necessary import for `clients_crud_instance`.

3.  **AttributeError for db.get_distinct_languages_for_template_type:** Exposed the `get_distinct_languages_for_template_type` function from `templates_crud.py` by adding it to the imports and `__all__` list in `db/__init__.py`.

4.  **Database error: no column named serial_number:** Updated `db/init_schema.py` to check for the existence of the `serial_number` column in the `ClientProjectProducts` table. If missing, it now attempts to add it using `ALTER TABLE`. This makes the schema initialization more resilient.

5.  **Missing SVG icons (dialog-cancel.svg, dialog-ok-apply.svg):** Added aliases in `icons.qrc` to map `dialog-cancel.svg` to `icons/x.svg` and `dialog-ok-apply.svg` to `icons/check.svg`. Note: `icons_rc.py` needs to be regenerated manually via `pyrcc5`.