### PR TITLE
Fix: Add missing logout method to MainDashboard

### DIFF
--- a/project_management/dashboard.py
+++ b/project_management/dashboard.py
@@ -284,6 +284,18 @@ class MainDashboard(QWidget): # Changed from QMainWindow to QWidget
         topbar_layout.addWidget(user_widget)
         self.nav_buttons[0].setObjectName("selected")
 
+    def logout(self):
+        print("Logout button clicked. Attempting to signal parent...")
+        if self.parent() and hasattr(self.parent(), 'handle_logout'):
+            self.parent().handle_logout()
+        else:
+            print("Parent has no 'handle_logout' method or parent is None.")
+            # As a fallback, if this dashboard is the main window, it might close itself.
+            # However, since it's a QWidget hosted by DocumentManager, this is less likely.
+            # For now, just printing is safest if parent communication fails.
+            # If direct parent communication is not desired, a signal/slot mechanism
+            # would be more appropriate, but requires changes in the parent class too.
+
     # ... (Placeholder methods gestion_notification, gestion_prospects, etc. remain unchanged) ...
     def gestion_notification(self): print("Notification management enabled.")
     def gestion_prospects(self): print("Prospect management enabled.")


### PR DESCRIPTION
Resolves an AttributeError that occurred when the logout button was clicked.

The `MainDashboard` class in `project_management/dashboard.py` was missing a `logout` method, which was referenced in the `setup_topbar` method.

This commit introduces the `logout` method to `MainDashboard`. The method currently:
1. Prints a confirmation message to the console.
2. Attempts to call `self.parent().handle_logout()` to delegate the logout operation to the parent component (e.g., `DocumentManager`).

Note: The parent component (`DocumentManager` or equivalent) will need to implement the `handle_logout` method to fully manage the logout process (e.g., switching to a login screen or exiting the application).