### PR TITLE
Fix: Add missing update_dashboard method to MainDashboard

### DIFF
--- a/project_management/dashboard.py
+++ b/project_management/dashboard.py
@@ -284,6 +284,18 @@ class MainDashboard(QWidget): # Changed from QMainWindow to QWidget
         topbar_layout.addWidget(user_widget)
         self.nav_buttons[0].setObjectName("selected")
 
+    def logout(self):
+        print("Logout button clicked. Attempting to signal parent...")
+        if self.parent() and hasattr(self.parent(), 'handle_logout'):
+            self.parent().handle_logout()
+        else:
+            print("Parent has no 'handle_logout' method or parent is None.")
+            # As a fallback, if this dashboard is the main window, it might close itself.
+            # However, since it's a QWidget hosted by DocumentManager, this is less likely.
+            # For now, just printing is safest if parent communication fails.
+            # If direct parent communication is not desired, a signal/slot mechanism
+            # would be more appropriate, but requires changes in the parent class too.
+
     # ... (Placeholder methods gestion_notification, gestion_prospects, etc. remain unchanged) ...
     def gestion_notification(self): print("Notification management enabled.")
     def gestion_prospects(self): print("Prospect management enabled.")
@@ -346,6 +358,37 @@ class MainDashboard(QWidget): # Changed from QMainWindow to QWidget
         layout.addWidget(graph_widget)
         layout.addWidget(activities_widget)
         self.main_content.addWidget(page)
+
+    def update_dashboard(self, selected_date=None):
+        if selected_date is None:
+            # If called by refresh button, use current date from picker
+            selected_date = self.date_picker.date().toPyDate()
+        else:
+            # If called by dateChanged signal, selected_date is a QDate object
+            selected_date = selected_date.toPyDate() # Convert QDate to Python date
+
+        print(f"update_dashboard called. Selected date: {selected_date}")
+
+        # Placeholder: Load/update Key Performance Indicators (KPIs)
+        # self.load_kpis(selected_date)
+        print("Placeholder: Would load KPIs for", selected_date)
+
+        # Placeholder: Load/update performance graph
+        # self.load_performance_graph(selected_date)
+        print("Placeholder: Would load performance graph for", selected_date)
+
+        # Placeholder: Load/update project progress graph
+        # self.load_project_progress_graph(selected_date)
+        print("Placeholder: Would load project progress graph for", selected_date)
+
+        # Placeholder: Load/update recent activities
+        # self.load_recent_activities(selected_date)
+        print("Placeholder: Would load recent activities for", selected_date)
+
+        # Example of how you might log this activity
+        # if self.current_user:
+        #     user_id = self.current_user.get('user_id')
+        #     log_activity(user_id, "Refreshed dashboard view", f"Date: {selected_date}")
 
     def setup_team_page(self):
         page = QWidget()


### PR DESCRIPTION
Resolves an AttributeError that occurred when the date picker changed or the refresh button was clicked on the dashboard page.

The `MainDashboard` class in `project_management/dashboard.py` was missing an `update_dashboard` method. This method is connected to the `dateChanged` signal of the date picker and the `clicked` signal of the refresh button in the `setup_dashboard_page` method.

This commit introduces the `update_dashboard` method to `MainDashboard`. The method currently:
1. Prints a confirmation message to the console, including the selected date.
2. Includes placeholder comments for where the actual logic to refresh dashboard components (KPIs, graphs, activities) should be added.
3. Handles being called with or without a date argument.