### PR TITLE
Fix: Correct TEMPLATES_DIR import in invoice_generation_logic

### DIFF
--- a/invoice_generation_logic.py
+++ b/invoice_generation_logic.py
@@ -10,15 +10,15 @@ from html_to_pdf_util import render_html_template, convert_html_to_pdf, WeasyPri
 # Adjust import path based on actual project structure
 # If this file is in, e.g., an 'invoicing' or 'logic' subdirectory:
 try:
-    from ..app_config import TEMPLATES_DIR
+    from ..app_config import CONFIG
     from ..db.cruds import clients_crud # Though not directly used in this func as per spec
 except (ImportError, ValueError):
     # Fallback if running script directly from its folder or structure is different
     # This assumes app_config.py and db/cruds/ are siblings of this file's parent directory
     # For robust imports, ensure your project's root is in PYTHONPATH
     # or use relative imports correctly based on your structure.
-    logging.warning("Could not perform relative imports for TEMPLATES_DIR/clients_crud. Attempting direct. This might fail if not in PYTHONPATH.")
-    from app_config import TEMPLATES_DIR
+    logging.warning("Could not perform relative imports for CONFIG/clients_crud. Attempting direct. This might fail if not in PYTHONPATH.")
+    from app_config import CONFIG
     from db.cruds import clients_crud
 
 
@@ -78,7 +78,7 @@ def generate_final_invoice_pdf(
 
     # Determine Template Path
     template_filename = "final_invoice_template.html"
-    template_path = os.path.join(TEMPLATES_DIR, target_language_code, template_filename)
+    template_path = os.path.join(CONFIG["templates_dir"], target_language_code, template_filename)
 
     if not os.path.exists(template_path):
         logging.error(f"Invoice template not found at: {template_path}")


### PR DESCRIPTION
The module invoice_generation_logic.py was attempting to import TEMPLATES_DIR directly from app_config.py, which does not exist as a direct export.

This change modifies invoice_generation_logic.py to import the CONFIG object from app_config and use CONFIG["templates_dir"] to access the templates directory path, as intended by the app_config.py structure.

This resolves the ImportError that prevented your application from starting up correctly.