### PR TITLE
Fix: Remove comments from CREATE TABLE Templates

### DIFF
--- a/db/init_schema.py
+++ b/db/init_schema.py
@@ -806,9 +806,9 @@ def initialize_database():
             created_by_user_id TEXT,
             FOREIGN KEY (created_by_user_id) REFERENCES Users (user_id),
             FOREIGN KEY (category_id) REFERENCES TemplateCategories(category_id) ON DELETE SET NULL,
-            client_id TEXT DEFAULT NULL, -- New column for client-specific templates
-            FOREIGN KEY (client_id) REFERENCES Clients(client_id) ON DELETE SET NULL, -- Added FK for client_id
-            UNIQUE (template_name, template_type, language_code, version) -- Existing unique constraint, client_id not added here for simplicity in ALTER
+            client_id TEXT DEFAULT NULL,
+            FOREIGN KEY (client_id) REFERENCES Clients(client_id) ON DELETE SET NULL,
+            UNIQUE (template_name, template_type, language_code, version)
         )""")
 
     # Idempotently add client_id column if it doesn't exist (for existing databases)


### PR DESCRIPTION
I removed trailing comments from several lines within the `CREATE TABLE IF NOT EXISTS Templates` statement in `db/init_schema.py`. This is to address a persistent `sqlite3.OperationalError: near "client_id": syntax error` that occurred during database initialization. The error pointed to this statement, and removing comments is an attempt to resolve any subtle parsing issues.