### PR TITLE
Fix: Improve document dialog and product display logic

### DIFF
--- a/client_widget.py
+++ b/client_widget.py
@@ -2373,12 +2373,39 @@ class ClientWidget(QWidget):
                     # 'client_id' might be in product_entry if ProductDialog was for multiple clients (not typical for this context)
                     # or if ProductDialog explicitly adds it. Assuming client_id comes from self.client_info.
 
-                    global_product_id = product_entry.get('product_id') # This is the ID from Products table
-                    quantity = product_entry.get('quantity')
-                    unit_price_override = product_entry.get('unit_price') # Dialog uses 'unit_price' for the override
+                    logging.info(f"Processing product_entry {processed_count + 1}/{len(products_list_data)}: {product_entry}")
+                    client_id_for_product = self.client_info.get('client_id')
+                    global_product_id = product_entry.get('product_id')
+                    quantity_raw = product_entry.get('quantity')
+                    unit_price_override_raw = product_entry.get('unit_price') # Dialog uses 'unit_price'
+
+                    quantity = None
+                    if quantity_raw is not None:
+                        try:
+                            quantity = float(quantity_raw)
+                            if quantity <= 0:
+                                logging.error(f"Invalid quantity '{quantity_raw}' for product {global_product_id}. Must be positive.")
+                                quantity = None # Treat as missing/invalid
+                        except ValueError:
+                            logging.error(f"Non-numeric quantity '{quantity_raw}' for product {global_product_id}.")
+                            quantity = None # Treat as missing/invalid
+
+                    unit_price_override = None # Initialize to None
+                    # unit_price_override should only be set if unit_price_override_raw is not None.
+                    # If unit_price_override_raw is None, it means no override is intended, and DB will use base_price.
+                    # If unit_price_override_raw is provided, it must be a valid float.
+                    if unit_price_override_raw is not None:
+                        try:
+                            unit_price_override = float(unit_price_override_raw)
+                            if unit_price_override < 0: # Negative prices are not allowed for an override
+                                logging.error(f"Invalid unit_price_override '{unit_price_override_raw}' for product {global_product_id}. Cannot be negative.")
+                                # If explicitly provided override is invalid, this is an error, treat as missing data for the 'all' check.
+                                unit_price_override = None # Mark as invalid for the 'all' check.
+                        except ValueError:
+                            logging.error(f"Non-numeric unit_price_override '{unit_price_override_raw}' for product {global_product_id}.")
+                            unit_price_override = None # Mark as invalid for the 'all' check.
 
                     # Determine project_id. It can be None.
-                    # project_identifier from client_info might be the name/code, not the DB ID.
                     # Assuming self.client_info.get('project_id') is the actual foreign key or None.
                     project_id_for_db = self.client_info.get('project_id', None)
                     if project_id_for_db is None:
@@ -2388,23 +2415,35 @@ class ClientWidget(QWidget):
                         logging.info(f"No 'project_id' found in client_info for client {client_id_for_product}. Product will be linked without a specific project.")
 
 
-                    if not all([client_id_for_product, global_product_id, quantity is not None, unit_price_override is not None]):
-                        logging.error(f"Skipping product entry due to missing data: {product_entry} for client_id {client_id_for_product}")
-                        QMessageBox.warning(self, self.tr("Données Produit Incomplètes"),
-                                            self.tr("Impossible d'ajouter un produit car certaines informations sont manquantes : {0}.").format(product_entry.get('name', 'Nom inconnu')))
+                    # Critical data for adding a link: client_id, product_id, quantity.
+                    # unit_price_override is optional in db_call_payload (None means use base price).
+                    # However, if unit_price_override_raw was provided but invalid, we treat it as a data error for this specific product entry.
+                    # The 'all' check needs to ensure that if an override was attempted (raw value not None) it must be valid (converted value not None).
+                    # And quantity must always be valid.
+                    conditions_met = all([
+                        client_id_for_product,
+                        global_product_id,
+                        quantity is not None, # Quantity must be valid positive number
+                        (unit_price_override_raw is None or unit_price_override is not None) # If override was given, it must be valid
+                    ])
+
+                    if not conditions_met:
+                        logging.error(f"Skipping product entry due to missing or invalid data (post-conversion): {product_entry} for client_id {client_id_for_product}. Quantity: {quantity}, Unit Price Override (converted): {unit_price_override}, Raw Override: {unit_price_override_raw}")
+                        QMessageBox.warning(self, self.tr("Données Produit Invalides ou Manquantes"),
+                                            self.tr("Impossible d'ajouter le produit '{0}' car la quantité ou le prix unitaire est invalide ou manquant.").format(product_entry.get('name', 'Nom inconnu')))
                         continue
 
+                    # unit_price_override in db_call_payload should be the converted float, or None if no override was intended/provided.
+                    # The add_product_to_client_or_project function handles None override by using base price.
                     db_call_payload = {
                         'client_id': client_id_for_product,
                         'product_id': global_product_id,
-                        'quantity': quantity,
-                        'unit_price_override': unit_price_override,
+                        'quantity': quantity, # Validated float
+                        'unit_price_override': unit_price_override, # Validated float or None
                         'project_id': project_id_for_db,
-                        # 'serial_number': None, # Default to None if not provided by dialog
-                        # 'purchase_confirmed_at': None, # Default to None
                     }
 
-                    logging.info(f"Attempting to link product with payload: {db_call_payload}")
+                    logging.info(f"Attempting to link product with validated payload: {db_call_payload}")
                     link_id = db_manager.add_product_to_client_or_project(db_call_payload)
 
                     if link_id:

--- a/dialogs/create_document_dialog.py
+++ b/dialogs/create_document_dialog.py
@@ -35,40 +35,44 @@ class CreateDocumentDialog(QDialog):
     def setup_ui(self):
         main_layout = QVBoxLayout(self)
         main_layout.setContentsMargins(15, 15, 15, 15)
-        main_layout.setSpacing(10)
+        main_layout.setSpacing(15) # Increased main layout spacing
 
         header_label = QLabel(self.tr("Sélectionner Documents à Créer"))
         header_label.setObjectName("dialogHeaderLabel")
         main_layout.addWidget(header_label)
 
         filters_group = QGroupBox(self.tr("Filtres"))
-        filters_group_layout = QVBoxLayout(filters_group)
-        filters_group_layout.setSpacing(10)
+        # Create a single QHBoxLayout for all filter controls and set it directly for the group
+        combined_filter_layout = QHBoxLayout(filters_group) # Set as layout for filters_group
+        combined_filter_layout.setSpacing(10)
+        combined_filter_layout.setContentsMargins(10, 10, 10, 10) # Add some margins inside the group box
 
-        filter_row1_layout = QHBoxLayout()
+        # Language Filter
         self.language_filter_label = QLabel(self.tr("Langue:"))
-        filter_row1_layout.addWidget(self.language_filter_label)
+        combined_filter_layout.addWidget(self.language_filter_label)
         self.language_filter_combo = QComboBox()
         self.language_filter_combo.addItems([self.tr("All"), "fr", "en", "ar", "tr", "pt"])
         self.language_filter_combo.setCurrentText(self.tr("All"))
-        filter_row1_layout.addWidget(self.language_filter_combo)
-        filter_row1_layout.addSpacing(20)
+        combined_filter_layout.addWidget(self.language_filter_combo)
+
+        # Extension Filter
+        combined_filter_layout.addSpacing(15)
         self.extension_filter_label = QLabel(self.tr("Extension:"))
-        filter_row1_layout.addWidget(self.extension_filter_label)
+        combined_filter_layout.addWidget(self.extension_filter_label)
         self.extension_filter_combo = QComboBox()
         self.extension_filter_combo.addItems([self.tr("All"), "HTML", "XLSX", "DOCX"])
         self.extension_filter_combo.setCurrentText("HTML")
-        filter_row1_layout.addWidget(self.extension_filter_combo)
-        filter_row1_layout.addStretch()
-        filters_group_layout.addLayout(filter_row1_layout)
+        combined_filter_layout.addWidget(self.extension_filter_combo)
 
-        filter_row2_layout = QHBoxLayout()
+        # Search Bar
+        combined_filter_layout.addSpacing(15)
         self.search_bar_label = QLabel(self.tr("Rechercher:"))
-        filter_row2_layout.addWidget(self.search_bar_label)
+        combined_filter_layout.addWidget(self.search_bar_label)
         self.search_bar = QLineEdit()
         self.search_bar.setPlaceholderText(self.tr("Filtrer par nom..."))
-        filter_row2_layout.addWidget(self.search_bar)
-        filters_group_layout.addLayout(filter_row2_layout)
+        combined_filter_layout.addWidget(self.search_bar)
+        self.search_bar.setSizePolicy(QSizePolicy.Expanding, QSizePolicy.Preferred)
+
         main_layout.addWidget(filters_group)
 
         self.order_select_combo = None
@@ -81,7 +85,9 @@ class CreateDocumentDialog(QDialog):
 
         if client_category == 'Distributeur' or has_multiple_events:
             order_group = QGroupBox(self.tr("Association Commande"))
-            order_group_layout = QHBoxLayout(order_group)
+            order_group_layout = QHBoxLayout(order_group) # Set as layout for order_group
+            order_group_layout.setSpacing(10)
+            order_group_layout.setContentsMargins(10, 10, 10, 10) # Add margins
 
             self.order_select_combo = QComboBox()
             self.order_select_combo.addItem(self.tr("Document Général (pas de commande spécifique)"), "NONE")
@@ -103,7 +109,9 @@ class CreateDocumentDialog(QDialog):
             main_layout.addWidget(order_group)
 
         templates_group = QGroupBox(self.tr("Modèles Disponibles"))
-        templates_group_layout = QVBoxLayout(templates_group)
+        templates_group_layout = QVBoxLayout(templates_group) # Set as layout for templates_group
+        templates_group_layout.setSpacing(10) # Or keep default if it looks better
+        templates_group_layout.setContentsMargins(10, 10, 10, 10) # Add margins
         self.templates_list = QListWidget()
         self.templates_list.setSelectionMode(QListWidget.MultiSelection)
         self.templates_list.setAlternatingRowColors(True)
@@ -175,36 +183,86 @@ class CreateDocumentDialog(QDialog):
             )
             if templates_from_db is None: templates_from_db = []
 
-            # Apply search text filter locally
-            filtered_templates = []
+            # Apply search text filter locally first
             if search_text:
-                for t_dict in templates_from_db:
-                    if search_text in t_dict.get('template_name', '').lower():
-                        filtered_templates.append(t_dict)
-            else:
-                filtered_templates = templates_from_db
+                templates_from_db = [
+                    t for t in templates_from_db
+                    if search_text in t.get('template_name', '').lower()
+                ]
 
-            # Separate default and other templates from the filtered list
-            default_templates = [t for t in filtered_templates if t.get('is_default_for_type_lang')]
-            other_templates = [t for t in filtered_templates if not t.get('is_default_for_type_lang')]
+            # Refine default status based on client-specificity
+            # Key: (template_type, language_code)
+            # Value: template_dict (prioritizing client-specific default)
+            effective_defaults_map = {}
+            client_specific_defaults_found = {} # Stores client-specific defaults: key=(type,lang), value=template_dict
 
-            # Combine them, defaults first
-            processed_templates = default_templates + other_templates
+            # First, identify all client-specific defaults from the filtered list
+            for t_dict in templates_from_db:
+                if t_dict.get('client_id') and t_dict.get('is_default_for_type_lang'):
+                    key = (t_dict.get('template_type'), t_dict.get('language_code'))
+                    # If multiple client-specific defaults for same type/lang (should ideally not happen if set_default is used)
+                    # we prefer the first one encountered or based on some criteria, here just overwriting.
+                    client_specific_defaults_found[key] = t_dict
 
-            for template_dict in processed_templates:
-                name = template_dict.get('template_name', 'N/A')
-                lang = template_dict.get('language_code', 'N/A')
-                base_file_name = template_dict.get('base_file_name', 'N/A')
-                is_default = template_dict.get('is_default_for_type_lang', False)
+            effective_defaults_map.update(client_specific_defaults_found)
+
+            # Second, add global defaults only if no client-specific default exists for that type/lang
+            for t_dict in templates_from_db:
+                if not t_dict.get('client_id') and t_dict.get('is_default_for_type_lang'):
+                    key = (t_dict.get('template_type'), t_dict.get('language_code'))
+                    if key not in effective_defaults_map: # No client-specific default for this type/lang
+                        effective_defaults_map[key] = t_dict
+
+            processed_templates_display_list = []
+            for t_dict in templates_from_db:
+                display_dict = t_dict.copy()
+                key = (t_dict.get('template_type'), t_dict.get('language_code'))
+
+                # Is this template the one chosen as the "effective" default for its type/lang?
+                # We compare using object identity (id()) in case of identical dicts from different sources (unlikely here but safe)
+                # or more simply, if the template_id matches (assuming template_id is unique and present)
+                effective_default_for_key = effective_defaults_map.get(key)
+                if effective_default_for_key and effective_default_for_key.get('template_id') == t_dict.get('template_id'):
+                    display_dict['is_display_default'] = True
+                else:
+                    display_dict['is_display_default'] = False
+                processed_templates_display_list.append(display_dict)
+
+            # Sort: display_defaults first, then by name/lang
+            # Global templates (client_id is None) should generally come after client-specific ones if names are similar etc.
+            # The primary sort is by the new 'is_display_default' flag.
+            processed_templates_display_list.sort(key=lambda t: (
+                not t['is_display_default'], # False (is_display_default=True) comes before True (is_display_default=False)
+                bool(t.get('client_id')),    # Client-specific (True) before global (False) for non-defaults or secondary sort
+                t.get('template_name', '').lower(),
+                t.get('language_code', '').lower()
+            ))
+
+            for template_dict_display_item in processed_templates_display_list:
+                name = template_dict_display_item.get('template_name', 'N/A')
+                lang = template_dict_display_item.get('language_code', 'N/A')
+                base_file_name = template_dict_display_item.get('base_file_name', 'N/A')
+                # Use 'is_display_default' for the UI indication
+                is_default_for_display = template_dict_display_item.get('is_display_default', False)
+
                 item_text = f"{name} ({lang}) - {base_file_name}"
-                if is_default: item_text = f"[D] {item_text}"
+                if is_default_for_display:
+                    item_text = f"[D] {item_text}"
+
                 item = QListWidgetItem(item_text)
-                item.setData(Qt.UserRole, template_dict)
-                if is_default:
-                    font = item.font(); font.setBold(True); item.setFont(font)
-                    # item.setBackground(QColor("#E0F0E0")) # QColor needs import
+                # Store the original template_dict (or its copy if modification is an issue) in UserRole
+                # Here, template_dict_display_item contains the original data + 'is_display_default'
+                item.setData(Qt.UserRole, template_dict_display_item)
+
+                if is_default_for_display:
+                    font = item.font()
+                    font.setBold(True)
+                    item.setFont(font)
+                    # item.setBackground(QColor("#E0F0E0")) # Optional: QColor needs import
                 self.templates_list.addItem(item)
         except Exception as e:
+            # Log the full traceback for detailed debugging
+            logging.error("Error loading templates in dialog", exc_info=True)
             QMessageBox.warning(self, self.tr("Erreur DB"), self.tr("Erreur de chargement des modèles:\n{0}").format(str(e)))
 
     def create_documents(self):

--- a/tests/dialogs/test_create_document_dialog.py
+++ b/tests/dialogs/test_create_document_dialog.py
@@ -1,0 +1,219 @@
+import unittest
+from unittest.mock import MagicMock, patch, call
+from PyQt5.QtWidgets import QApplication, QListWidgetItem
+from PyQt5.QtGui import QFont
+
+# Ensure QApplication instance exists
+app = None
+def setUpModule():
+    global app
+    app = QApplication.instance()
+    if app is None:
+        app = QApplication([])
+
+def tearDownModule():
+    global app
+    app = None
+
+
+# Assuming dialogs.create_document_dialog is the path to your module
+# Adjust the import path based on your project structure
+from dialogs.create_document_dialog import CreateDocumentDialog
+# Mock db_manager before it's imported by the dialog
+# This is a common pattern but might need adjustment if db_manager is imported differently
+# For now, we will patch it directly where CreateDocumentDialog uses it.
+
+
+class TestCreateDocumentDialog(unittest.TestCase):
+
+    def setUp(self):
+        """Set up for each test."""
+        self.mock_client_info = {
+            'client_id': 'test_client_1',
+            'selected_languages': ['fr', 'en'],
+            'category': 'SomeCategory'
+            # Add other fields as minimally required by CreateDocumentDialog constructor
+        }
+        self.mock_config = {
+            'templates_dir': '/fake/templates/dir'
+            # Add other config fields as needed
+        }
+
+        # It's important that db_manager is patched *before* CreateDocumentDialog instance is created
+        # if the dialog imports db_manager at the module level and uses it in __init__ or setup_ui.
+        # However, the provided dialog seems to call db_manager.get_all_templates within load_templates,
+        # so patching it via @patch decorator on the test method or setUp should be fine.
+
+    @patch('dialogs.create_document_dialog.db_manager')
+    def test_load_templates_no_default_templates(self, mock_db_manager):
+        """Test load_templates when no default templates are returned."""
+        mock_db_manager.get_all_templates.return_value = [
+            {'template_id': 1, 'template_name': 'T1', 'language_code': 'fr', 'base_file_name': 't1.html', 'template_type': 'document_html', 'is_default_for_type_lang': False, 'client_id': None},
+            {'template_id': 2, 'template_name': 'T2', 'language_code': 'en', 'base_file_name': 't2.html', 'template_type': 'document_html', 'is_default_for_type_lang': False, 'client_id': 'test_client_1'},
+        ]
+
+        dialog = CreateDocumentDialog(self.mock_client_info, self.mock_config)
+
+        # Call load_templates directly or ensure it's called by dialog setup
+        # dialog.load_templates() # setup_ui calls load_templates, so this might be redundant if instance creation is enough
+
+        self.assertEqual(dialog.templates_list.count(), 2)
+        for i in range(dialog.templates_list.count()):
+            item = dialog.templates_list.item(i)
+            self.assertFalse(item.text().startswith("[D]"))
+            self.assertFalse(item.font().bold())
+
+            # Verify data stored in item
+            item_data = item.data(Qt.UserRole)
+            self.assertIsNotNone(item_data)
+            # is_display_default should be False based on the refined logic
+            self.assertFalse(item_data.get('is_display_default', False))
+
+
+    @patch('dialogs.create_document_dialog.db_manager')
+    def test_load_templates_global_default_only(self, mock_db_manager):
+        """Test with only a global default template."""
+        mock_db_manager.get_all_templates.return_value = [
+            {'template_id': 1, 'template_name': 'GlobalDefault', 'language_code': 'fr', 'base_file_name': 'gd.html', 'template_type': 'document_html', 'is_default_for_type_lang': True, 'client_id': None},
+            {'template_id': 2, 'template_name': 'T2', 'language_code': 'en', 'base_file_name': 't2.html', 'template_type': 'document_html', 'is_default_for_type_lang': False, 'client_id': 'test_client_1'},
+        ]
+        dialog = CreateDocumentDialog(self.mock_client_info, self.mock_config)
+
+        self.assertEqual(dialog.templates_list.count(), 2)
+
+        item0_data = dialog.templates_list.item(0).data(Qt.UserRole) # Assuming sort puts default first
+        item1_data = dialog.templates_list.item(1).data(Qt.UserRole)
+
+        # Determine which item is the default one based on 'is_display_default'
+        default_item_text_prefix = "[D] GlobalDefault"
+        non_default_item_text_prefix = "T2"
+
+        found_default = False
+        found_non_default = False
+
+        for i in range(dialog.templates_list.count()):
+            item = dialog.templates_list.item(i)
+            item_data = item.data(Qt.UserRole)
+            if item_data.get('is_display_default'):
+                self.assertTrue(item.text().startswith(default_item_text_prefix))
+                self.assertTrue(item.font().bold())
+                found_default = True
+            else:
+                self.assertTrue(item.text().startswith(non_default_item_text_prefix)) # Check actual name
+                self.assertFalse(item.font().bold())
+                found_non_default = True
+
+        self.assertTrue(found_default, "Global default template was not marked as display default.")
+        self.assertTrue(found_non_default, "Non-default template was not found or processed correctly.")
+
+
+    @patch('dialogs.create_document_dialog.db_manager')
+    def test_load_templates_client_specific_default_only(self, mock_db_manager):
+        """Test with only a client-specific default template."""
+        mock_db_manager.get_all_templates.return_value = [
+            {'template_id': 1, 'template_name': 'T1', 'language_code': 'fr', 'base_file_name': 't1.html', 'template_type': 'document_html', 'is_default_for_type_lang': False, 'client_id': None},
+            {'template_id': 2, 'template_name': 'ClientDefault', 'language_code': 'en', 'base_file_name': 'cd.html', 'template_type': 'document_html', 'is_default_for_type_lang': True, 'client_id': 'test_client_1'},
+        ]
+        dialog = CreateDocumentDialog(self.mock_client_info, self.mock_config)
+        self.assertEqual(dialog.templates_list.count(), 2)
+
+        default_item_text_prefix = "[D] ClientDefault"
+        non_default_item_text_prefix = "T1"
+
+        found_default = False
+        found_non_default = False
+
+        for i in range(dialog.templates_list.count()):
+            item = dialog.templates_list.item(i)
+            item_data = item.data(Qt.UserRole)
+            if item_data.get('is_display_default'):
+                self.assertTrue(item.text().startswith(default_item_text_prefix))
+                self.assertTrue(item.font().bold())
+                self.assertEqual(item_data.get('client_id'), 'test_client_1')
+                found_default = True
+            else:
+                self.assertTrue(item.text().startswith(non_default_item_text_prefix))
+                self.assertFalse(item.font().bold())
+                found_non_default = True
+
+        self.assertTrue(found_default, "Client-specific default template was not marked as display default.")
+        self.assertTrue(found_non_default, "Non-default template was not found.")
+
+
+    @patch('dialogs.create_document_dialog.db_manager')
+    def test_load_templates_client_overrides_global_default(self, mock_db_manager):
+        """Test client-specific default overrides global default for the same type/lang."""
+        mock_db_manager.get_all_templates.return_value = [
+            {'template_id': 1, 'template_name': 'GlobalFR', 'language_code': 'fr', 'base_file_name': 'gfr.html', 'template_type': 'document_html', 'is_default_for_type_lang': True, 'client_id': None},
+            {'template_id': 2, 'template_name': 'ClientFR', 'language_code': 'fr', 'base_file_name': 'cfr.html', 'template_type': 'document_html', 'is_default_for_type_lang': True, 'client_id': 'test_client_1'},
+            {'template_id': 3, 'template_name': 'OtherEN', 'language_code': 'en', 'base_file_name': 'oen.html', 'template_type': 'document_html', 'is_default_for_type_lang': False, 'client_id': None},
+        ]
+        dialog = CreateDocumentDialog(self.mock_client_info, self.mock_config)
+        self.assertEqual(dialog.templates_list.count(), 3)
+
+        client_default_count = 0
+        displayed_as_default_count = 0
+
+        for i in range(dialog.templates_list.count()):
+            item = dialog.templates_list.item(i)
+            item_data = item.data(Qt.UserRole)
+            is_display_default = item_data.get('is_display_default', False)
+
+            if is_display_default:
+                displayed_as_default_count +=1
+                # This one MUST be the client-specific one
+                self.assertEqual(item_data.get('template_name'), 'ClientFR', "ClientFR should be the one displayed as default.")
+                self.assertTrue(item.text().startswith("[D] ClientFR"))
+                self.assertTrue(item.font().bold())
+
+            if item_data.get('template_name') == 'GlobalFR':
+                self.assertFalse(is_display_default, "GlobalFR should NOT be displayed as default when client-specific one exists.")
+                self.assertFalse(item.text().startswith("[D]"), "GlobalFR text should not have [D] prefix.")
+                self.assertFalse(item.font().bold(), "GlobalFR font should not be bold.")
+
+
+        self.assertEqual(displayed_as_default_count, 1, "Only one template (ClientFR) should be marked as display default for fr/document_html.")
+
+    @patch('dialogs.create_document_dialog.db_manager')
+    def test_load_templates_multiple_defaults_different_type_lang(self, mock_db_manager):
+        """Test multiple defaults for different types/languages are handled correctly."""
+        mock_db_manager.get_all_templates.return_value = [
+            {'template_id': 1, 'template_name': 'GlobalFR_HTML', 'language_code': 'fr', 'base_file_name': 'gfr.html', 'template_type': 'document_html', 'is_default_for_type_lang': True, 'client_id': None},
+            {'template_id': 2, 'template_name': 'ClientEN_HTML', 'language_code': 'en', 'base_file_name': 'cen.html', 'template_type': 'document_html', 'is_default_for_type_lang': True, 'client_id': 'test_client_1'},
+            {'template_id': 3, 'template_name': 'GlobalFR_DOCX', 'language_code': 'fr', 'base_file_name': 'gfr.docx', 'template_type': 'document_word', 'is_default_for_type_lang': True, 'client_id': None},
+            {'template_id': 4, 'template_name': 'NonDefault', 'language_code': 'fr', 'base_file_name': 'nd.html', 'template_type': 'document_html', 'is_default_for_type_lang': False, 'client_id': None},
+        ]
+        dialog = CreateDocumentDialog(self.mock_client_info, self.mock_config)
+        # Simulate selecting "All" for language and extension to ensure all these are processed
+        dialog.language_filter_combo.setCurrentText("All")
+        dialog.extension_filter_combo.setCurrentText("All") # This will trigger load_templates
+        # Note: direct call to dialog.load_templates() might be needed if signals aren't firing in test env
+        # or if setup_ui's initial call isn't sufficient after filter changes.
+        # The provided CreateDocumentDialog calls load_templates in setup_ui, and signals connect to it.
+        # Forcing a reload after filter changes:
+        dialog.load_templates()
+
+
+        self.assertEqual(dialog.templates_list.count(), 4)
+
+        display_default_names = []
+        for i in range(dialog.templates_list.count()):
+            item = dialog.templates_list.item(i)
+            item_data = item.data(Qt.UserRole)
+            if item_data.get('is_display_default'):
+                display_default_names.append(item_data.get('template_name'))
+                self.assertTrue(item.text().startswith("[D]"))
+                self.assertTrue(item.font().bold())
+            else:
+                self.assertFalse(item.text().startswith("[D]"))
+                self.assertFalse(item.font().bold())
+
+        self.assertEqual(len(display_default_names), 3, "Should be 3 templates marked as display default.")
+        self.assertIn('GlobalFR_HTML', display_default_names)
+        self.assertIn('ClientEN_HTML', display_default_names)
+        self.assertIn('GlobalFR_DOCX', display_default_names)
+
+    # TODO: Add tests for filter functionality (language, extension, search text)
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/widgets/test_client_widget.py
+++ b/tests/widgets/test_client_widget.py
@@ -1,0 +1,218 @@
+import unittest
+from unittest.mock import MagicMock, patch, call, ANY
+from PyQt5.QtWidgets import QApplication, QDialog
+
+# Ensure QApplication instance exists
+app = None
+def setUpModule():
+    global app
+    app = QApplication.instance()
+    if app is None:
+        app = QApplication([])
+
+def tearDownModule():
+    global app
+    app = None
+
+# Adjust the import path based on your project structure
+from client_widget import ClientWidget
+
+# Mock external dependencies that ClientWidget uses directly or indirectly
+# These might be imported at the module level of client_widget.py or its imports
+# For example, db_manager, various dialogs, etc.
+
+# Mocking MAIN_MODULE_*** globals that ClientWidget._import_main_elements() tries to set.
+# This is a bit complex due to the dynamic import mechanism in ClientWidget.
+# We need to ensure these are patched *before* ClientWidget is instantiated.
+
+mock_config_for_client_widget = {
+    'app_root_dir': '/fake/app_root',
+    'templates_dir': '/fake/templates',
+    # Add other necessary config keys
+}
+
+# It's crucial to patch 'client_widget.MAIN_MODULE_CONFIG' and other MAIN_MODULE_* globals
+# if ClientWidget relies on them being set by _import_main_elements.
+# Alternatively, if _import_main_elements can be prevented or its imports mocked, that's cleaner.
+
+@patch('client_widget.MAIN_MODULE_CONFIG', mock_config_for_client_widget)
+@patch('client_widget.MAIN_MODULE_DATABASE_NAME', 'fake_db_path')
+@patch('client_widget.MAIN_MODULE_PRODUCT_DIALOG') # Mock the ProductDialog class
+@patch('client_widget.db_manager') # Mock the db_manager module used by ClientWidget
+class TestClientWidgetAddProduct(unittest.TestCase):
+
+    def setUp(self):
+        self.mock_client_info = {
+            'client_id': 'client123',
+            'client_name': 'Test Client',
+            'project_id': 'project456', # Assuming project_id might be used
+            'base_folder_path': '/fake/client/folder',
+            # Add other fields ClientWidget constructor or setup_ui might need
+            'status_id': 'status_active',
+            'category': 'TestCategory',
+            'selected_languages': 'fr,en',
+        }
+
+        self.mock_notification_manager = MagicMock()
+
+        # Instantiate ClientWidget
+        # We need to ensure all heavy UI setup that's not relevant to the test
+        # is either mocked or doesn't break the test.
+        # ClientWidget's __init__ calls setup_ui(), which creates many UI elements.
+        # For focused testing of add_product/load_products, we might not need full UI.
+        # However, these methods interact with self.products_table.
+
+        # Patching methods that might be problematic during setup_ui if not needed for these tests
+        with patch.object(ClientWidget, 'setup_ui', MagicMock(return_value=None)) as mock_setup_ui, \
+             patch.object(ClientWidget, 'load_statuses', MagicMock(return_value=None)), \
+             patch.object(ClientWidget, 'populate_details_layout', MagicMock(return_value=None)), \
+             patch.object(ClientWidget, 'load_contacts', MagicMock(return_value=None)), \
+             patch.object(ClientWidget, 'populate_doc_table', MagicMock(return_value=None)), \
+             patch.object(ClientWidget, 'load_document_notes_filters', MagicMock(return_value=None)), \
+             patch.object(ClientWidget, 'load_document_notes_table', MagicMock(return_value=None)), \
+             patch.object(ClientWidget, 'load_products_for_dimension_tab', MagicMock(return_value=None)), \
+             patch.object(ClientWidget, 'update_sav_tab_visibility', MagicMock(return_value=None)), \
+             patch.object(ClientWidget, 'load_assigned_vendors_personnel', MagicMock(return_value=None)), \
+             patch.object(ClientWidget, 'load_assigned_technicians', MagicMock(return_value=None)), \
+             patch.object(ClientWidget, 'load_assigned_transporters', MagicMock(return_value=None)), \
+             patch.object(ClientWidget, 'load_assigned_freight_forwarders', MagicMock(return_value=None)):
+
+            self.widget = ClientWidget(
+                client_info=self.mock_client_info,
+                config=mock_config_for_client_widget, # Use the globally mocked one
+                app_root_dir='/fake_app_root_dir',    # Or get from mock_config
+                notification_manager=self.mock_notification_manager
+            )
+            # Now, after instance creation with a mocked setup_ui, manually create critical components.
+            # Or, allow setup_ui to run but mock its problematic parts.
+            # For this test, we need self.products_table and self.product_lang_filter_combo
+            # Let's assume setup_ui was run (by removing the patch for it for a moment)
+            # and only specific UI elements are mocked if they cause issues.
+            # The above patch of setup_ui is very broad. Let's try to be more specific.
+
+        # Minimal re-setup for products_table related things
+        # This is tricky because setup_ui does a LOT.
+        # A better approach if ClientWidget is hard to instantiate in tests:
+        # Refactor logic from ClientWidget into non-GUI classes/functions.
+        # For now, we'll try to mock parts of setup_ui or its callees.
+
+        # Let's assume self.widget is created. We need to mock self.products_table
+        self.widget.products_table = MagicMock()
+        self.widget.product_lang_filter_combo = MagicMock() # Used by load_products
+        self.widget.products_empty_label = MagicMock() # Used by load_products
+
+    def test_add_product_single_valid_product(self, mock_db_manager, MockProductDialog):
+        """Test adding a single valid product."""
+        # Configure ProductDialog mock
+        mock_dialog_instance = MockProductDialog.return_value
+        mock_dialog_instance.exec_.return_value = QDialog.Accepted
+        mock_dialog_instance.get_data.return_value = [
+            {'product_id': 'prod1', 'name': 'Product 1', 'quantity': '2', 'unit_price': '10.50'}
+        ]
+
+        # Configure db_manager mocks
+        mock_db_manager.add_product_to_client_or_project.return_value = 1 # Simulate successful DB add (returns link_id)
+        mock_db_manager.get_products_for_client_or_project.return_value = [
+            {'client_project_product_id': 1, 'product_id': 'prod1', 'product_name': 'Product 1',
+             'quantity': 2.0, 'unit_price_override': 10.50, 'base_unit_price': 10.0, # assume base is 10
+             'total_price_calculated': 21.0, 'language_code': 'fr'} # Match expected data for load_products
+        ]
+
+        # Patch QMessageBox for this test
+        with patch('client_widget.QMessageBox') as mock_qmessagebox:
+            self.widget.add_product()
+
+        # Assertions
+        MockProductDialog.assert_called_once_with(self.mock_client_info['client_id'], ANY, parent=self.widget)
+
+        expected_payload = {
+            'client_id': self.mock_client_info['client_id'],
+            'product_id': 'prod1',
+            'quantity': 2.0,
+            'unit_price_override': 10.50,
+            'project_id': self.mock_client_info['project_id']
+        }
+        mock_db_manager.add_product_to_client_or_project.assert_called_once_with(expected_payload)
+
+        # Check that load_products was called (implicitly by checking get_products_for_client_or_project)
+        mock_db_manager.get_products_for_client_or_project.assert_called_once_with(self.mock_client_info['client_id'], project_id=None)
+
+        # Check if products_table was populated (simplified check)
+        self.widget.products_table.setRowCount.assert_called_with(0) # Cleared first
+        self.widget.products_table.insertRow.assert_called_once() # One product added
+        self.widget.products_table.setItem.assert_any_call(0, 1, ANY) # Check if name column was set for row 0
+
+        mock_qmessagebox.information.assert_called_once() # Success message
+        mock_qmessagebox.warning.assert_not_called() # No warnings for data issues
+
+
+    def test_add_product_multiple_products_one_invalid_data(self, mock_db_manager, MockProductDialog):
+        """Test adding multiple products, one with invalid quantity."""
+        mock_dialog_instance = MockProductDialog.return_value
+        mock_dialog_instance.exec_.return_value = QDialog.Accepted
+        mock_dialog_instance.get_data.return_value = [
+            {'product_id': 'prod1', 'name': 'Product 1', 'quantity': '2', 'unit_price': '10.00'},
+            {'product_id': 'prod2', 'name': 'Product 2', 'quantity': 'invalid_qty', 'unit_price': '20.00'}, # Invalid
+            {'product_id': 'prod3', 'name': 'Product 3', 'quantity': '3', 'unit_price': '5.00'}
+        ]
+
+        # Simulate DB calls
+        # db.add only called for valid products
+        mock_db_manager.add_product_to_client_or_project.side_effect = [1, 2] # Link IDs for prod1, prod3
+
+        # db.get returns only successfully added products
+        mock_db_manager.get_products_for_client_or_project.return_value = [
+            {'client_project_product_id': 1, 'product_id': 'prod1', 'product_name': 'Product 1', 'quantity': 2.0, 'unit_price_override': 10.00, 'total_price_calculated': 20.0, 'language_code': 'fr'},
+            {'client_project_product_id': 2, 'product_id': 'prod3', 'product_name': 'Product 3', 'quantity': 3.0, 'unit_price_override': 5.00, 'total_price_calculated': 15.0, 'language_code': 'fr'}
+        ]
+
+        with patch('client_widget.QMessageBox') as mock_qmessagebox:
+            self.widget.add_product()
+
+        # Assertions
+        self.assertEqual(mock_db_manager.add_product_to_client_or_project.call_count, 2)
+        calls_to_db_add = [
+            call({'client_id': 'client123', 'product_id': 'prod1', 'quantity': 2.0, 'unit_price_override': 10.0, 'project_id': 'project456'}),
+            call({'client_id': 'client123', 'product_id': 'prod3', 'quantity': 3.0, 'unit_price_override': 5.0, 'project_id': 'project456'})
+        ]
+        mock_db_manager.add_product_to_client_or_project.assert_has_calls(calls_to_db_add, any_order=False)
+
+        mock_qmessagebox.warning.assert_called_once() # For the invalid product
+        # Check the title of the warning
+        args, _ = mock_qmessagebox.warning.call_args
+        self.assertEqual(args[1], self.widget.tr("Données Produit Invalides ou Manquantes"))
+
+
+        # Check that load_products was called
+        mock_db_manager.get_products_for_client_or_project.assert_called_once_with(self.mock_client_info['client_id'], project_id=None)
+
+        # Check table population
+        self.assertEqual(self.widget.products_table.insertRow.call_count, 2) # Prod1 and Prod3
+
+
+    def test_add_product_db_failure(self, mock_db_manager, MockProductDialog):
+        """Test scenario where adding a product to DB fails."""
+        mock_dialog_instance = MockProductDialog.return_value
+        mock_dialog_instance.exec_.return_value = QDialog.Accepted
+        mock_dialog_instance.get_data.return_value = [
+            {'product_id': 'prod1', 'name': 'Product 1', 'quantity': '1', 'unit_price': '10.00'}
+        ]
+
+        mock_db_manager.add_product_to_client_or_project.return_value = None # Simulate DB failure
+        mock_db_manager.get_products_for_client_or_project.return_value = [] # No products after failed add
+
+        with patch('client_widget.QMessageBox') as mock_qmessagebox:
+            self.widget.add_product()
+
+        mock_db_manager.add_product_to_client_or_project.assert_called_once()
+        mock_qmessagebox.warning.assert_any_call(self.widget, self.widget.tr("Erreur Base de Données"), ANY)
+
+        # load_products is still called
+        mock_db_manager.get_products_for_client_or_project.assert_called_once()
+        self.widget.products_table.insertRow.assert_not_called() # No product should be added to table
+
+    # TODO: Add more tests for load_products directly if needed, e.g. different language filters, empty data from DB etc.
+    # For now, load_products is indirectly tested via add_product.
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
This commit addresses several UI and logic issues:

1.  **CreateDocumentDialog Enhancements:**
    *   Default documents (client-specific or global) are now correctly prioritized and displayed in the `CreateDocumentDialog`. Client-specific defaults take precedence. Only one template per type/language is marked as the primary default `[D]`.
    *   The filter controls (language, extension, search) in `CreateDocumentDialog` are now consolidated onto a single line for a more compact UI.
    *   Minor layout spacing and margin adjustments were made for better visual consistency.

2.  **ClientWidget Product Display Fix:**
    *   Resolved an issue where only the first product added in a batch was displayed correctly. Improved data validation in `ClientWidget.add_product` ensures that all valid products are processed and added. Invalid entries are skipped with a notification to you.
    *   The product list (`load_products`) is now reliably updated after adding products.

3.  **Unit Tests:**
    *   Added unit tests for `CreateDocumentDialog` to verify the new default template display logic.
    *   Added unit tests for `ClientWidget.add_product` to cover scenarios of adding multiple products, including those with invalid data, ensuring correct processing and UI updates.