### PR TITLE
Fix: Import correct NotificationManager in main.py

### DIFF
--- a/main.py
+++ b/main.py
@@ -31,7 +31,7 @@ from PyQt5.QtWidgets import QDialog # Required for QDialog.Accepted check (alrea
 # from initial_setup_dialog import InitialSetupDialog # Redundant import, already imported above
 # import db as db_manager # For db initialization - already imported above, now using 'import db'
 from main_window import DocumentManager # The main application window
-from project_management.notifications import NotificationManager # Added for notifications
+from notifications import NotificationManager # Added for notifications
 from db.cruds.users_crud import users_crud_instance # Added for default operational user
 from PyQt5.QtWidgets import QMessageBox # Added for error dialog
 


### PR DESCRIPTION
Previously, main.py was importing NotificationManager from project_management.notifications, which does not have the expected `show` method. This caused AttributeError exceptions when trying to display global notifications.

This change corrects the import to use the NotificationManager from the top-level `notifications.py` file, which provides the correct `show` method for toast-style notifications.

This resolves the AttributeError encountered in contact_dialog.py, document_manager_logic.py, and main_window.py when attempting to display notifications after certain actions (e.g., adding a contact, creating a client).