### PR TITLE
feat: Enhance utility document management and previews

### DIFF
--- a/db/__init__.py
+++ b/db/__init__.py
@@ -31,7 +31,7 @@ from .cruds.client_documents_crud import (
     delete_client_document_note,
     get_client_document_note_by_id,
 )
-from .utils import get_document_context_data
+from .utils import get_document_context_data, save_general_document_file, delete_general_document_file
 # For proforma_invoices_crud, we will NOT add them here due to SQLAlchemy vs sqlite3 differences.
 # Files using proforma_invoices_crud will import it directly.
 from .cruds.application_settings_crud import get_setting, set_setting
@@ -120,7 +120,9 @@ from .cruds.templates_crud import ( # Modified
     get_distinct_template_languages,
     get_distinct_template_types,
     get_filtered_templates,
-    get_distinct_languages_for_template_type
+    get_distinct_languages_for_template_type,
+    add_utility_document_template,
+    get_utility_documents,
 )
 from .cruds.cover_page_templates_crud import get_cover_page_template_by_id
 from .cruds.milestones_crud import (
@@ -228,6 +230,8 @@ __all__ = [
     "delete_client_document_note",
     "get_client_document_note_by_id",
     "get_document_context_data",
+    "save_general_document_file",
+    "delete_general_document_file",
     "get_all_products", # Added
     "get_all_products_for_selection_filtered", # Added
 
@@ -300,6 +304,8 @@ __all__ = [
     "get_distinct_template_types", # Added from templates_crud.py
     "get_distinct_languages_for_template_type", # Added this line
     "get_filtered_templates", # Added from templates_crud.py
+    "add_utility_document_template", # Added from templates_crud.py
+    "get_utility_documents", # Added from templates_crud.py
     "get_cover_page_template_by_id", # Now from cover_page_templates_crud
     "get_milestones_for_project",
     "add_milestone",


### PR DESCRIPTION
This commit implements several enhancements to utility document handling:

1.  **Implemented Missing DB & File Helpers:**
    *   Added `db.save_general_document_file` and `db.delete_general_document_file` to `db.utils` for managing physical template files.
    *   Added `db.add_utility_document_template` and `db.get_utility_documents` to `db.cruds.templates_crud` (and exposed via `db` package). These functions specifically handle templates categorized as 'Document Utilitaires', streamlining their management.

2.  **Seeded Default Utility Documents:**
    *   Updated `db/db_seed.py` to seed 7 default utility documents (HTML templates for contact page, cover page, technical specifications, and warranty) in English and French.
    *   These documents are now correctly categorized under 'Document Utilitaires' and will be available by default.

3.  **Enhanced HTML Previews:**
    *   The `UtilityDocumentManagerDialog` now includes a `QWebEngineView` pane to provide rich HTML previews for selected utility documents. This preview correctly loads local resources like CSS and images.
    *   Verified that `ClientWidget` correctly launches `HtmlEditor` for HTML documents, and `HtmlEditor` uses `get_document_context_data` for dynamic, context-aware previews.

4.  **Verified Document Listing:**
    *   Confirmed that `UtilityDocumentManagerDialog` now correctly lists the default and any added utility documents due to the new helper functions and seeding.

These changes ensure that the list of utility documents, especially the default ones, is correctly displayed and that HTML previews are functional and render accurately.