### PR TITLE
Refactor: Resolve circular dependency for app_config import in db/uti…

### DIFF
--- a/db/utils.py
+++ b/db/utils.py
@@ -6,7 +6,6 @@ import sys # Import sys
 from datetime import datetime
 import logging # Keep logging import
 import shutil
-from app_config import CONFIG
 
 # --- Configuration Import ---
 # Get the application root directory (parent of 'db' directory)
@@ -372,6 +371,7 @@ def save_general_document_file(source_file_path: str, document_type_subfolder: s
     Returns:
         str | None: The full path to the saved file on success, or None on error.
     """
+    from app_config import CONFIG
     try:
         templates_dir = CONFIG.get("templates_dir", "templates")
         target_dir = os.path.join(templates_dir, document_type_subfolder, language_code)
@@ -400,6 +400,7 @@ def delete_general_document_file(document_type_subfolder: str, language_code: st
     Returns:
         bool: True if deletion was successful or if the file didn't exist, False on OSError during deletion.
     """
+    from app_config import CONFIG
     try:
         templates_dir = CONFIG.get("templates_dir", "templates")
         file_path_to_delete = os.path.join(templates_dir, document_type_subfolder, language_code, base_file_name)


### PR DESCRIPTION
…ls.py

I removed the global import of `app_config.CONFIG` from `db/utils.py`. Instead, `CONFIG` is now imported locally within the functions `save_general_document_file` and `delete_general_document_file` where it is needed.

This change prevents a `ModuleNotFoundError: No module named 'app_config'` that occurred due to an import cycle when `db/utils.py` was loaded prematurely through the CRUDS modules during application startup.