### PR TITLE
Fix ImportError for CONFIG in db_seed.py

### DIFF
--- a/app_config.py
+++ b/app_config.py
@@ -26,3 +26,17 @@ else:
 
 DEFAULT_TEMPLATES_DIR = os.path.join(APP_ROOT_DIR, TEMPLATES_SUBDIR)
 DEFAULT_CLIENTS_DIR = os.path.join(APP_ROOT_DIR, CLIENTS_SUBDIR)
+
+CONFIG = {
+    "app_root_dir": APP_ROOT_DIR,
+    "default_templates_dir": DEFAULT_TEMPLATES_DIR,
+    "default_clients_dir": DEFAULT_CLIENTS_DIR,
+    "config_dir_name": CONFIG_DIR_NAME,
+    "config_file_name": CONFIG_FILE_NAME,
+    "templates_subdir": TEMPLATES_SUBDIR,
+    "clients_subdir": CLIENTS_SUBDIR,
+    "spec_tech_template_name": SPEC_TECH_TEMPLATE_NAME,
+    "proforma_template_name": PROFORMA_TEMPLATE_NAME,
+    "contrat_vente_template_name": CONTRAT_VENTE_TEMPLATE_NAME,
+    "packing_liste_template_name": PACKING_LISTE_TEMPLATE_NAME,
+}

--- a/db/db_seed.py
+++ b/db/db_seed.py
@@ -552,7 +552,7 @@ def _seed_default_utility_templates(cursor: sqlite3.Cursor, conn: sqlite3.Connec
         # Let's assume the `template_type` (e.g., 'document_html') is used as the subfolder for organization within templates_dir.
 
         expected_runtime_template_path = os.path.join(
-            CONFIG.get("templates_dir", "templates"), # e.g., /app/templates
+            CONFIG.get("default_templates_dir", "templates"), # e.g., /app/templates
             template_type, # e.g., document_html (derived from extension)
             language_code, # e.g., en
             base_file_name # e.g., contact_page_template.html


### PR DESCRIPTION
The `CONFIG` dictionary was not defined in `app_config.py`, causing an ImportError when `db/db_seed.py` tried to import it.

This commit defines the `CONFIG` dictionary in `app_config.py` and populates it with necessary configuration values.

Additionally, `db/db_seed.py` was updated to use the correct key `default_templates_dir` when accessing the templates directory from the `CONFIG` object.