### PR TITLE
feat(botpress): Implement real-time notifications and unread indicators

### DIFF
--- a/botpress_integration/api_client.py
+++ b/botpress_integration/api_client.py
@@ -7,127 +7,215 @@ class BotpressAPIError(Exception):
     pass
 
 class BotpressClient:
-    def __init__(self, api_key, bot_id):
+    def __init__(self, api_key, bot_id, base_url="https://api.botpress.cloud/v1/"):
         self.api_key = api_key
         self.bot_id = bot_id
-        self.base_url = f"https://api.botpress.cloud/v1/bots/{self.bot_id}" # Example, not hit in mock
-        logging.info(f"BotpressClient initialized for bot_id: {self.bot_id}")
+        # Ensure base_url ends with a slash
+        if not base_url.endswith('/'):
+            base_url += '/'
+        self.base_url = base_url
+        self.bot_specific_url = f"{self.base_url}bots/{self.bot_id}"
+        logging.info(f"BotpressClient initialized for bot_id: {self.bot_id} using base_url: {self.base_url}")
 
-    def send_message(self, message_text):
+    def send_message(self, message_text, conversation_id=None):
         """
-        Simulates sending a message to Botpress.
-        In a real implementation, this would make an HTTP POST request.
+        Sends a message to the Botpress bot.
+        Optionally, a conversation_id can be provided to send the message to a specific conversation.
         """
-        logging.debug(f"Attempting to send message: '{message_text}'")
+        logging.debug(f"Attempting to send message: '{message_text}' to bot {self.bot_id}, conversation_id: {conversation_id}")
+        endpoint_url = f"{self.bot_specific_url}/messages"
+
+        headers = {
+            "Authorization": f"Bearer {self.api_key}",
+            "Content-Type": "application/json"
+        }
+        payload = {
+            "text": message_text,
+            "type": "text"
+        }
+        if conversation_id:
+            payload["conversationId"] = conversation_id
+
         try:
-            # Simulate random errors
-            if random.random() < 0.1: # 10% chance of connection error
-                logging.error("Simulated ConnectionError during send_message")
-                raise requests.exceptions.ConnectionError("Simulated network problem")
-            if random.random() < 0.05: # 5% chance of API error
-                logging.error("Simulated BotpressAPIError during send_message")
-                raise BotpressAPIError("Simulated Botpress API failure (e.g., invalid token, bot down)")
-
-            # Mock successful implementation:
-            logging.info(f"Simulating successful send_message to Botpress: '{message_text}'")
-            # In a real scenario, you would use requests.post:
-            # headers = {
-            #     "Authorization": f"Bearer {self.api_key}",
-            #     "Content-Type": "application/json"
-            # }
-            # payload = {"text": message_text, "type": "text", "conversationId": "default"} # conversationId might be needed
-            # response = requests.post(f"{self.base_url}/messages", json=payload, headers=headers)
-            # response.raise_for_status() # Raise an exception for HTTP errors (4xx or 5xx)
-            # return response.json()
-            return f"Botpress mock response to: {message_text}"
-
-        except requests.exceptions.ConnectionError as e:
-            logging.error(f"Connection error while sending message: {e}", exc_info=True)
-            raise  # Re-raise for UI to handle or display
+            response = requests.post(endpoint_url, json=payload, headers=headers, timeout=10) # 10s timeout
+            response.raise_for_status()  # Raises HTTPError for bad responses (4xx or 5xx)
+            logging.info(f"Message sent successfully to {endpoint_url}. Response: {response.json()}")
+            return response.json()
         except requests.exceptions.Timeout as e:
-            logging.error(f"Timeout while sending message: {e}", exc_info=True)
-            raise
+            logging.error(f"Timeout occurred while sending message to {endpoint_url}: {e}", exc_info=True)
+            raise BotpressAPIError(f"Timeout sending message to Botpress: {e}")
+        except requests.exceptions.ConnectionError as e:
+            logging.error(f"Connection error occurred while sending message to {endpoint_url}: {e}", exc_info=True)
+            raise BotpressAPIError(f"Connection error sending message to Botpress: {e}")
         except requests.exceptions.HTTPError as e:
-            logging.error(f"HTTP error while sending message: {e} - Response: {e.response.text if e.response else 'N/A'}", exc_info=True)
-            raise BotpressAPIError(f"HTTP Error: {e.response.status_code if e.response else 'Unknown'}")
-        except BotpressAPIError as e: # Custom API error
-            logging.error(f"Botpress API error while sending message: {e}", exc_info=True)
-            raise
-        except Exception as e:
-            logging.error(f"Unexpected error in send_message: {e}", exc_info=True)
-            raise BotpressAPIError(f"An unexpected error occurred: {e}")
+            logging.error(f"HTTP error for {endpoint_url}: {e.response.status_code} - {e.response.text}", exc_info=True)
+            raise BotpressAPIError(f"Botpress API HTTP error: {e.response.status_code} - {e.response.text}")
+        except requests.exceptions.RequestException as e: # Catch any other requests-related errors
+            logging.error(f"Error sending message to {endpoint_url}: {e}", exc_info=True)
+            raise BotpressAPIError(f"Failed to send message to Botpress: {e}")
+        except Exception as e: # Catch any other unexpected errors
+            logging.error(f"Unexpected error in send_message to {endpoint_url}: {e}", exc_info=True)
+            raise BotpressAPIError(f"An unexpected error occurred while sending message: {e}")
 
+    def get_conversations(self, conversation_id=None):
+        """
+        Retrieves messages.
+        If conversation_id is provided, fetches messages for that specific conversation.
+        Otherwise, fetches generic messages for the bot (actual behavior depends on Botpress API).
+        """
+        if conversation_id:
+            endpoint_url = f"{self.bot_specific_url}/conversations/{conversation_id}/messages"
+            logging.debug(f"Attempting to get messages for bot {self.bot_id}, conversation_id: {conversation_id}")
+        else:
+            endpoint_url = f"{self.bot_specific_url}/messages"
+            logging.debug(f"Attempting to get messages for bot {self.bot_id} (no specific conversation_id)")
 
-    def get_conversations(self):
-        """
-        Simulates retrieving conversation history from Botpress.
-        In a real implementation, this would make an HTTP GET request.
-        """
-        logging.debug("Attempting to get conversation history.")
+        headers = {
+            "Authorization": f"Bearer {self.api_key}"
+        }
+
         try:
-            # Simulate random errors
-            if random.random() < 0.1: # 10% chance of connection error
-                logging.error("Simulated ConnectionError during get_conversations")
-                raise requests.exceptions.ConnectionError("Simulated network problem retrieving history")
-            if random.random() < 0.05: # 5% chance of API error
-                logging.error("Simulated BotpressAPIError during get_conversations")
-                raise BotpressAPIError("Simulated Botpress API failure retrieving history")
-
-            # Mock successful implementation:
-            logging.info("Simulating successful get_conversations from Botpress.")
-            # In a real scenario, you would use requests.get:
-            # headers = {"Authorization": f"Bearer {self.api_key}"}
-            # response = requests.get(f"{self.base_url}/conversations/default/messages", headers=headers) # Adjust endpoint as needed
-            # response.raise_for_status()
-            # return response.json().get("messages", [])
-            return [
-                {"sender": "Bot", "text": "Hello! This is a mock history message."},
-                {"sender": "User", "text": "I previously asked about my account."},
-                {"sender": "Bot", "text": "And I mockingly offered to help."}
-            ]
-        except requests.exceptions.ConnectionError as e:
-            logging.error(f"Connection error while getting conversations: {e}", exc_info=True)
-            raise
+            response = requests.get(endpoint_url, headers=headers, timeout=10) # 10s timeout
+            response.raise_for_status()  # Raises HTTPError for bad responses (4xx or 5xx)
+            # Assuming the response JSON has a "messages" key containing a list of messages.
+            # This might need adjustment based on the actual Botpress API response structure.
+            messages = response.json().get("messages", [])
+            logging.info(f"Successfully retrieved {len(messages)} messages from {endpoint_url}.")
+            return messages
         except requests.exceptions.Timeout as e:
-            logging.error(f"Timeout while getting conversations: {e}", exc_info=True)
-            raise
+            logging.error(f"Timeout occurred while getting messages from {endpoint_url}: {e}", exc_info=True)
+            raise BotpressAPIError(f"Timeout getting messages from Botpress: {e}")
+        except requests.exceptions.ConnectionError as e:
+            logging.error(f"Connection error occurred while getting messages from {endpoint_url}: {e}", exc_info=True)
+            raise BotpressAPIError(f"Connection error getting messages from Botpress: {e}")
         except requests.exceptions.HTTPError as e:
-            logging.error(f"HTTP error while getting conversations: {e} - Response: {e.response.text if e.response else 'N/A'}", exc_info=True)
-            raise BotpressAPIError(f"HTTP Error: {e.response.status_code if e.response else 'Unknown'}")
-        except BotpressAPIError as e: # Custom API error
-            logging.error(f"Botpress API error while getting conversations: {e}", exc_info=True)
-            raise
-        except Exception as e:
-            logging.error(f"Unexpected error in get_conversations: {e}", exc_info=True)
-            raise BotpressAPIError(f"An unexpected error occurred retrieving conversations: {e}")
+            logging.error(f"HTTP error for {endpoint_url}: {e.response.status_code} - {e.response.text}", exc_info=True)
+            raise BotpressAPIError(f"Botpress API HTTP error: {e.response.status_code} - {e.response.text}")
+        except requests.exceptions.RequestException as e: # Catch any other requests-related errors
+            logging.error(f"Error getting messages from {endpoint_url}: {e}", exc_info=True)
+            raise BotpressAPIError(f"Failed to get messages from Botpress: {e}")
+        except Exception as e: # Catch any other unexpected errors
+            logging.error(f"Unexpected error in get_conversations from {endpoint_url}: {e}", exc_info=True)
+            raise BotpressAPIError(f"An unexpected error occurred while retrieving messages: {e}")
 
+    def get_bot_info(self):
+        """
+        Retrieves information about the bot.
+        This can be used to validate the bot_id and API key.
+        """
+        # The endpoint for bot information is typically the bot-specific URL itself.
+        endpoint_url = self.bot_specific_url
+        logging.debug(f"Attempting to get bot info from {endpoint_url}")
+
+        headers = {
+            "Authorization": f"Bearer {self.api_key}"
+        }
+
+        try:
+            response = requests.get(endpoint_url, headers=headers, timeout=10)
+            response.raise_for_status()
+            bot_info = response.json()
+            logging.info(f"Successfully retrieved bot info from {endpoint_url}: {bot_info}")
+            return bot_info
+        except requests.exceptions.Timeout as e:
+            logging.error(f"Timeout occurred while getting bot info from {endpoint_url}: {e}", exc_info=True)
+            raise BotpressAPIError(f"Timeout getting bot info: {e}")
+        except requests.exceptions.ConnectionError as e:
+            logging.error(f"Connection error occurred while getting bot info from {endpoint_url}: {e}", exc_info=True)
+            raise BotpressAPIError(f"Connection error getting bot info: {e}")
+        except requests.exceptions.HTTPError as e:
+            logging.error(f"HTTP error for {endpoint_url}: {e.response.status_code} - {e.response.text}", exc_info=True)
+            raise BotpressAPIError(f"Botpress API HTTP error getting bot info: {e.response.status_code} - {e.response.text}")
+        except requests.exceptions.RequestException as e:
+            logging.error(f"Error getting bot info from {endpoint_url}: {e}", exc_info=True)
+            raise BotpressAPIError(f"Failed to get bot info: {e}")
+        except Exception as e:
+            logging.error(f"Unexpected error in get_bot_info from {endpoint_url}: {e}", exc_info=True)
+            raise BotpressAPIError(f"An unexpected error occurred while retrieving bot info: {e}")
 
 if __name__ == '__main__':
     # Example Usage (for testing purposes)
     # Configure basic logging for testing this module directly
-    logging.basicConfig(level=logging.DEBUG, format='%(asctime)s - %(levelname)s - %(filename)s:%(lineno)d - %(message)s')
+    logging.basicConfig(level=logging.INFO, format='%(asctime)s - %(levelname)s - %(filename)s:%(lineno)d - %(message)s')
 
-    mock_api_key = "MOCK_API_KEY"
-    mock_bot_id = "MOCK_BOT_ID"
+    # IMPORTANT: Replace with your actual API key and Bot ID for real testing.
+    # Using mock values will likely result in authentication errors (e.g., 401 Unauthorized).
+    actual_api_key = "MOCK_API_KEY_REPLACE_ME_FOR_REAL_TESTS"
+    actual_bot_id = "MOCK_BOT_ID_REPLACE_ME_FOR_REAL_TESTS"
+    # Example: Test with a specific conversation ID
+    mock_conversation_id = "mock_conv_12345"
 
-    client = BotpressClient(api_key=mock_api_key, bot_id=mock_bot_id)
+    # To use a custom Botpress instance (e.g. self-hosted):
+    # custom_base_url = "http://localhost:3000/api/v1/"
+    # client = BotpressClient(api_key=actual_api_key, bot_id=actual_bot_id, base_url=custom_base_url)
 
-    print("\n--- Testing send_message (will run multiple times to check random errors) ---")
-    for i in range(5):
-        try:
-            print(f"Attempt {i+1}:")
-            response = client.send_message(f"Test message {i+1}")
-            print(f"  send_message response: {response}")
-        except (requests.exceptions.ConnectionError, BotpressAPIError, Exception) as e:
-            print(f"  send_message caught error: {e.__class__.__name__} - {e}")
+    client = BotpressClient(api_key=actual_api_key, bot_id=actual_bot_id)
 
-    print("\n--- Testing get_conversations (will run multiple times to check random errors) ---")
-    for i in range(3):
-        try:
-            print(f"Attempt {i+1}:")
-            conversations = client.get_conversations()
-            print("  get_conversations response:")
-            for msg in conversations:
-                print(f"  - {msg['sender']}: {msg['text']}")
-        except (requests.exceptions.ConnectionError, BotpressAPIError, Exception) as e:
-            print(f"  get_conversations caught error: {e.__class__.__name__} - {e}")
+    print("--- Example API Client Usage ---")
+    print(f"Using Bot ID: {client.bot_id}")
+    print(f"Using Base URL: {client.base_url}")
+    print(f"Bot-specific URL: {client.bot_specific_url}")
+    print("\nNOTE: The following API calls will use MOCK credentials by default.")
+    print("Replace MOCK_API_KEY and MOCK_BOT_ID with real credentials to interact with Botpress.")
+    print("Expect errors (like 401 Unauthorized) if using mock credentials against a real API endpoint.")
+
+    print("\n--- Testing get_bot_info ---")
+    try:
+        bot_info = client.get_bot_info()
+        print(f"  get_bot_info response: {bot_info}")
+    except BotpressAPIError as e:
+        print(f"  get_bot_info caught error: {e}")
+    except Exception as e:
+        print(f"  get_bot_info caught unexpected error: {e}")
+
+    print("\n--- Testing send_message (without conversation_id) ---")
+    try:
+        test_message = "Hello from the API client example (no conv_id)!"
+        response = client.send_message(test_message)
+        print(f"  send_message response to '{test_message}': {response}")
+    except BotpressAPIError as e:
+        print(f"  send_message caught error: {e}")
+    except Exception as e:
+        print(f"  send_message caught unexpected error: {e}")
+
+    print("\n--- Testing send_message (with conversation_id) ---")
+    try:
+        test_message_with_conv = "Hello from the API client example (with conv_id)!"
+        response_with_conv = client.send_message(test_message_with_conv, conversation_id=mock_conversation_id)
+        print(f"  send_message response to '{test_message_with_conv}' (conv_id: {mock_conversation_id}): {response_with_conv}")
+    except BotpressAPIError as e:
+        print(f"  send_message (with conv_id) caught error: {e}")
+    except Exception as e:
+        print(f"  send_message (with conv_id) caught unexpected error: {e}")
+
+    print("\n--- Testing get_conversations (fetching messages without conversation_id) ---")
+    try:
+        messages = client.get_conversations()
+        print(f"  get_conversations response (no conv_id) (messages received: {len(messages)}):")
+        if messages:
+            for i, msg in enumerate(messages[:3]): # Print first 3 messages
+                print(f"    Message {i+1}: {msg}")
+        elif not messages and actual_api_key != "MOCK_API_KEY_REPLACE_ME_FOR_REAL_TESTS":
+             print("  No messages found (no conv_id), or the endpoint/bot configuration needs review.")
+        else:
+            print("  No messages retrieved (no conv_id) (as expected with mock credentials or if bot has no messages).")
+    except BotpressAPIError as e:
+        print(f"  get_conversations (no conv_id) caught error: {e}")
+    except Exception as e:
+        print(f"  get_conversations (no conv_id) caught unexpected error: {e}")
+
+    print("\n--- Testing get_conversations (fetching messages with conversation_id) ---")
+    try:
+        messages_with_conv = client.get_conversations(conversation_id=mock_conversation_id)
+        print(f"  get_conversations response (conv_id: {mock_conversation_id}) (messages received: {len(messages_with_conv)}):")
+        if messages_with_conv:
+            for i, msg in enumerate(messages_with_conv[:3]): # Print first 3 messages
+                print(f"    Message {i+1}: {msg}")
+        elif not messages_with_conv and actual_api_key != "MOCK_API_KEY_REPLACE_ME_FOR_REAL_TESTS":
+            print(f"  No messages found for conv_id {mock_conversation_id}, or the endpoint/bot configuration needs review.")
+        else:
+            print(f"  No messages retrieved for conv_id {mock_conversation_id} (as expected with mock credentials or if bot has no messages for this specific conversation).")
+    except BotpressAPIError as e:
+        print(f"  get_conversations (with conv_id) caught error: {e}")
+    except Exception as e:
+        print(f"  get_conversations (with conv_id) caught unexpected error: {e}")

--- a/botpress_integration/crud.py
+++ b/botpress_integration/crud.py
@@ -1,6 +1,9 @@
 from sqlalchemy.orm import Session
 from sqlalchemy.exc import SQLAlchemyError
-from . import models # Assuming models.py is in the same directory
+from . import models
+from .models import Conversation, Message, UserBotpressSettings, UserPrompt # Explicit imports for clarity
+from typing import Optional
+from datetime import datetime
 import logging
 
 # --- Botpress Settings CRUD ---
@@ -20,7 +23,8 @@ def create_or_update_botpress_settings(
     user_id: str,
     api_key: str,
     bot_id: str,
-    preferred_language: str = "en"
+    preferred_language: str = "en",
+    base_url: str | None = None
 ) -> models.UserBotpressSettings:
     """
     Creates new Botpress settings for a user or updates existing ones.
@@ -32,6 +36,7 @@ def create_or_update_botpress_settings(
             db_settings.api_key = api_key
             db_settings.bot_id = bot_id
             db_settings.preferred_language = preferred_language
+            db_settings.base_url = base_url
             # Update other fields as needed
         else:
             logging.info(f"Creating new Botpress settings for user_id: {user_id}")
@@ -39,7 +44,8 @@ def create_or_update_botpress_settings(
                 user_id=user_id,
                 api_key=api_key,
                 bot_id=bot_id,
-                preferred_language=preferred_language
+                preferred_language=preferred_language,
+                base_url=base_url
             )
             db.add(db_settings)
         db.commit()
@@ -181,6 +187,18 @@ def delete_user_prompt(db: Session, prompt_id: int) -> bool:
         db.rollback()
         raise
 
+def count_unread_bot_messages(db: Session) -> int:
+    """Counts all unread messages not sent by 'user'."""
+    try:
+        count = db.query(models.Message).filter(
+            models.Message.sender_type != 'user',
+            models.Message.is_read == False
+        ).count()
+        return count
+    except SQLAlchemyError as e:
+        logging.error(f"DB error in count_unread_bot_messages: {e}", exc_info=True)
+        raise
+
 if __name__ == "__main__":
     # This is for example usage and basic testing.
     # Configure basic logging for testing this module directly
@@ -231,7 +249,8 @@ if __name__ == "__main__":
                 db,
                 user_id=USER_ID_TEST,
                 api_key="crud_test_api_key_1",
-                bot_id="crud_test_bot_id_1"
+                bot_id="crud_test_bot_id_1",
+                base_url="http://localhost:3000/api/v1"
             )
             logging.info(f"Created/Updated settings: {settings}")
 
@@ -239,18 +258,21 @@ if __name__ == "__main__":
             logging.info(f"Retrieved settings: {retrieved_settings}")
             assert retrieved_settings is not None
             assert retrieved_settings.api_key == "crud_test_api_key_1"
+            assert retrieved_settings.base_url == "http://localhost:3000/api/v1"
 
-            logging.info("Updating settings...")
+            logging.info("Updating settings (clearing base_url)...")
             settings = create_or_update_botpress_settings(
                 db,
                 user_id=USER_ID_TEST,
                 api_key="crud_test_api_key_updated",
                 bot_id="crud_test_bot_id_updated",
-                preferred_language="fr"
+                preferred_language="fr",
+                base_url=None # Test clearing it
             )
             logging.info(f"Updated settings: {settings}")
             assert settings.api_key == "crud_test_api_key_updated"
             assert settings.preferred_language == "fr"
+            assert settings.base_url is None
 
             # --- Test User Prompts ---
             if retrieved_settings: # Should be true if above passed
@@ -319,6 +341,383 @@ if __name__ == "__main__":
                 logging.info(f"Cleaned up settings for user: {USER_ID_TEST}")
             except Exception as e:
                 logging.error(f"Failed to clean up settings for {USER_ID_TEST} post-test: {e}", exc_info=True)
+
+            if db:
+                db.close()
+                logging.info("CRUD __main__ test: Database session closed.")
+    else:
+        logging.info("Skipping CRUD __main__ tests as database session is not available.")
+
+# --- Conversation CRUD ---
+
+def get_conversation_by_botpress_id(db: Session, botpress_conversation_id: str) -> models.Conversation | None:
+    """Retrieves a conversation by its Botpress ID."""
+    try:
+        return db.query(models.Conversation).filter(models.Conversation.botpress_conversation_id == botpress_conversation_id).first()
+    except SQLAlchemyError as e:
+        logging.error(f"DB error in get_conversation_by_botpress_id for bp_conv_id {botpress_conversation_id}: {e}", exc_info=True)
+        raise
+
+def create_conversation(db: Session, botpress_conversation_id: str, channel_type: Optional[str] = None, user_identifier_on_channel: Optional[str] = None, status: str = 'active') -> models.Conversation:
+    """Creates a new conversation."""
+    try:
+        logging.info(f"Creating new conversation with Botpress ID: {botpress_conversation_id}")
+        db_conversation = models.Conversation(
+            botpress_conversation_id=botpress_conversation_id,
+            channel_type=channel_type,
+            user_identifier_on_channel=user_identifier_on_channel,
+            status=status,
+            last_message_timestamp=datetime.utcnow() # Initialize with current time
+        )
+        db.add(db_conversation)
+        db.commit()
+        db.refresh(db_conversation)
+        return db_conversation
+    except SQLAlchemyError as e:
+        logging.error(f"DB error in create_conversation for bp_conv_id {botpress_conversation_id}: {e}", exc_info=True)
+        db.rollback()
+        raise
+
+def get_or_create_conversation(db: Session, botpress_conversation_id: str, channel_type: Optional[str] = None, user_identifier_on_channel: Optional[str] = None) -> models.Conversation:
+    """Tries to get by botpress_conversation_id, if not found, creates one."""
+    try:
+        conversation = get_conversation_by_botpress_id(db, botpress_conversation_id)
+        if conversation:
+            # Optionally update channel_type or user_identifier if provided and different
+            # For now, just return the existing one.
+            # conversation.last_message_timestamp = datetime.utcnow() # Potentially update this here or in add_message
+            # db.commit()
+            # db.refresh(conversation)
+            return conversation
+        return create_conversation(db, botpress_conversation_id, channel_type, user_identifier_on_channel)
+    except SQLAlchemyError as e: # Should be caught by called functions, but as a safeguard
+        logging.error(f"DB error in get_or_create_conversation for bp_conv_id {botpress_conversation_id}: {e}", exc_info=True)
+        raise
+
+
+def update_conversation_status(db: Session, conversation_id: int, status: str) -> models.Conversation | None:
+    """Updates the status of a conversation."""
+    try:
+        db_conversation = db.query(models.Conversation).filter(models.Conversation.id == conversation_id).first()
+        if db_conversation:
+            logging.info(f"Updating status to '{status}' for conversation ID {conversation_id}")
+            db_conversation.status = status
+            db.commit()
+            db.refresh(db_conversation)
+        return db_conversation
+    except SQLAlchemyError as e:
+        logging.error(f"DB error in update_conversation_status for conv_id {conversation_id}: {e}", exc_info=True)
+        db.rollback()
+        raise
+
+def update_conversation_timestamp(db: Session, conversation_id: int, last_message_timestamp: datetime) -> models.Conversation | None:
+    """Updates the last_message_timestamp of a conversation."""
+    try:
+        db_conversation = db.query(models.Conversation).filter(models.Conversation.id == conversation_id).first()
+        if db_conversation:
+            logging.info(f"Updating last_message_timestamp for conversation ID {conversation_id}")
+            db_conversation.last_message_timestamp = last_message_timestamp
+            db.commit()
+            db.refresh(db_conversation)
+        return db_conversation
+    except SQLAlchemyError as e:
+        logging.error(f"DB error in update_conversation_timestamp for conv_id {conversation_id}: {e}", exc_info=True)
+        db.rollback()
+        raise
+
+def get_recent_conversations(db: Session, limit: int = 20) -> list[models.Conversation]:
+    """Fetches recent conversations, ordered by last_message_timestamp descending."""
+    try:
+        return db.query(models.Conversation).order_by(models.Conversation.last_message_timestamp.desc()).limit(limit).all()
+    except SQLAlchemyError as e:
+        logging.error(f"DB error in get_recent_conversations: {e}", exc_info=True)
+        raise
+
+# --- Message CRUD ---
+
+def add_message(db: Session, conversation_id: int, sender_type: str, content: str, timestamp: datetime, botpress_message_id: Optional[str] = None, suggestions: Optional[str] = None, is_read: Optional[bool] = None) -> models.Message:
+    """Adds a message to a conversation. Also updates the parent conversation's last_message_timestamp."""
+    try:
+        logging.info(f"Adding message to conversation ID {conversation_id} from '{sender_type}'")
+
+        if is_read is not None:
+            final_is_read = is_read
+        elif sender_type == 'user':
+            final_is_read = True
+        else: # bot, agent, system
+            final_is_read = False
+
+        db_message = models.Message(
+            conversation_id=conversation_id,
+            botpress_message_id=botpress_message_id,
+            sender_type=sender_type,
+            content=content,
+            timestamp=timestamp,
+            suggestions=suggestions,
+            is_read=final_is_read
+        )
+        db.add(db_message)
+
+        # Update conversation's last_message_timestamp
+        conversation = db.query(models.Conversation).filter(models.Conversation.id == conversation_id).first()
+        if conversation:
+            conversation.last_message_timestamp = timestamp
+
+        db.commit()
+        db.refresh(db_message)
+        if conversation: # Refresh conversation if it was updated
+             db.refresh(conversation)
+        return db_message
+    except SQLAlchemyError as e:
+        logging.error(f"DB error in add_message for conv_id {conversation_id}: {e}", exc_info=True)
+        db.rollback()
+        raise
+
+def get_messages_for_conversation(db: Session, conversation_id: int, limit: int = 50, offset: int = 0) -> list[models.Message]:
+    """Fetches messages for a conversation, ordered by timestamp ascending."""
+    try:
+        return db.query(models.Message).filter(models.Message.conversation_id == conversation_id).order_by(models.Message.timestamp.asc()).offset(offset).limit(limit).all()
+    except SQLAlchemyError as e:
+        logging.error(f"DB error in get_messages_for_conversation for conv_id {conversation_id}: {e}", exc_info=True)
+        raise
+
+def get_message_by_botpress_id(db: Session, botpress_message_id: str) -> models.Message | None:
+    """Retrieves a message by its Botpress ID."""
+    try:
+        return db.query(models.Message).filter(models.Message.botpress_message_id == botpress_message_id).first()
+    except SQLAlchemyError as e:
+        logging.error(f"DB error in get_message_by_botpress_id for bp_msg_id {botpress_message_id}: {e}", exc_info=True)
+        raise
+
+def mark_messages_as_read(db: Session, conversation_id: int) -> int:
+    """Marks all unread messages in a conversation as read. Returns the count of messages marked as read."""
+    try:
+        unread_messages_query = db.query(models.Message).filter(
+            models.Message.conversation_id == conversation_id,
+            models.Message.is_read == False
+        )
+        count = unread_messages_query.count()
+        if count > 0:
+            unread_messages_query.update({models.Message.is_read: True}, synchronize_session=False)
+            db.commit()
+            logging.info(f"Marked {count} messages as read for conversation_id {conversation_id}")
+        return count
+    except SQLAlchemyError as e:
+        logging.error(f"DB error in mark_messages_as_read for conv_id {conversation_id}: {e}", exc_info=True)
+        db.rollback()
+        raise
+
+if __name__ == "__main__":
+    # This is for example usage and basic testing.
+    # Configure basic logging for testing this module directly
+    logging.basicConfig(level=logging.DEBUG, format='%(asctime)s - %(levelname)s - %(filename)s:%(lineno)d - %(message)s')
+
+    # If running this file directly, you might need to adjust imports.
+    # For direct execution, ensure models.py ran `create_db_and_tables()`
+    # and that `botpress_integration.db` is in the expected location.
+    try:
+        # Ensure models are available for the test
+        from models import SessionLocal, UserBotpressSettings, UserPrompt, Conversation, Message, create_db_and_tables
+    except ImportError:
+        logging.warning("Could not import models directly for __main__ test in crud.py. Assuming DB is set up.")
+        SessionLocal = None
+        pass
+
+
+    if SessionLocal:
+        try:
+            create_db_and_tables()
+            logging.info("Database tables ensured/created for CRUD __main__ test.")
+        except Exception as e:
+            logging.error(f"Failed to create/ensure tables in CRUD __main__: {e}", exc_info=True)
+            SessionLocal = None # Do not proceed if table creation fails
+
+        db: Session = SessionLocal() if SessionLocal else None
+    else:
+        logging.error("SessionLocal is None. Cannot run CRUD __main__ tests.")
+        db = None
+
+    # --- Test Botpress Settings (only if db is available) ---
+    if db:
+        USER_ID_TEST = "crud_test_user_123"
+        BP_CONV_ID_TEST = "bp_conv_crud_test_001"
+        BP_MSG_ID_TEST_1 = "bp_msg_crud_test_001a"
+        BP_MSG_ID_TEST_2 = "bp_msg_crud_test_001b"
+
+        # Clean up previous test data
+        try:
+            logging.info(f"--- Initial Cleanup ---")
+            # Delete messages first due to FK constraints
+            existing_conv_for_cleanup = get_conversation_by_botpress_id(db, BP_CONV_ID_TEST)
+            if existing_conv_for_cleanup:
+                messages_to_delete = get_messages_for_conversation(db, existing_conv_for_cleanup.id)
+                for msg in messages_to_delete:
+                    db.delete(msg)
+                db.commit()
+                db.delete(existing_conv_for_cleanup)
+                db.commit()
+                logging.info(f"Cleaned up old conversation and messages for {BP_CONV_ID_TEST}")
+
+            delete_botpress_settings(db, USER_ID_TEST) # This also cleans its prompts
+            logging.info(f"Cleaned up old settings for {USER_ID_TEST}")
+
+        except Exception as e:
+            logging.warning(f"Could not clean up old data, might not exist: {e}", exc_info=True)
+            db.rollback() # Ensure session is clean if cleanup had issues
+
+        logging.info(f"--- Testing UserBotpressSettings CRUD ---")
+        try:
+            settings = create_or_update_botpress_settings(
+                db, user_id=USER_ID_TEST, api_key="key", bot_id="bot"
+            )
+            logging.info(f"Created settings: {settings}")
+            retrieved_settings = get_botpress_settings(db, USER_ID_TEST)
+            assert retrieved_settings is not None and retrieved_settings.user_id == USER_ID_TEST
+
+            logging.info(f"--- Testing Conversation and Message CRUD ---")
+            # Create conversation
+            logging.info(f"Creating conversation with BP ID: {BP_CONV_ID_TEST}")
+            conv = get_or_create_conversation(db, BP_CONV_ID_TEST, channel_type="test_channel", user_identifier_on_channel="test_user_on_channel")
+            assert conv is not None
+            assert conv.botpress_conversation_id == BP_CONV_ID_TEST
+            assert conv.channel_type == "test_channel"
+            logging.info(f"Created/Retrieved conversation: {conv}")
+
+            # Add messages
+            ts1 = datetime.utcnow()
+            msg1 = add_message(db, conv.id, "user", "Hello Bot!", ts1, BP_MSG_ID_TEST_1)
+            assert msg1 is not None and msg1.botpress_message_id == BP_MSG_ID_TEST_1
+            logging.info(f"Added message 1: {msg1}")
+
+            # Verify conversation timestamp was updated
+            conv_after_msg1 = get_conversation_by_botpress_id(db, BP_CONV_ID_TEST)
+            assert conv_after_msg1 is not None
+            # Timestamps might have microsecond differences from Python's datetime.utcnow() vs DB storage.
+            # Compare by ensuring it's very close or check date and hour/minute.
+            assert conv_after_msg1.last_message_timestamp is not None
+            assert abs((conv_after_msg1.last_message_timestamp - ts1).total_seconds()) < 1
+            assert msg1.is_read is True # User message should be read
+
+            ts2 = datetime.utcnow()
+            suggestions_json = '[{"title": "Opt1"}, {"payload": "p1"}]'
+            msg2 = add_message(db, conv.id, "bot", "Hello User!", ts2, BP_MSG_ID_TEST_2, suggestions=suggestions_json)
+            assert msg2 is not None and msg2.content == "Hello User!"
+            assert msg2.is_read is False # Bot message should be unread initially
+            assert msg2.suggestions == suggestions_json
+            logging.info(f"Added message 2 (bot, unread): {msg2}")
+
+            # Add another bot message, explicitly set as read (e.g. if it was an old message being synced)
+            ts3 = datetime.utcnow()
+            msg3 = add_message(db, conv.id, "bot", "Old bot message", ts3, "bp_msg_3", is_read=True)
+            assert msg3.is_read is True
+            logging.info(f"Added message 3 (bot, read): {msg3}")
+
+
+            conv_after_msgs = get_conversation_by_botpress_id(db, BP_CONV_ID_TEST)
+            assert conv_after_msgs is not None
+            assert abs((conv_after_msgs.last_message_timestamp - ts3).total_seconds()) < 1 # Timestamp of last message
+
+            # Get messages for conversation
+            messages = get_messages_for_conversation(db, conv.id)
+            assert len(messages) == 3
+            assert messages[0].content == "Hello Bot!" and messages[0].is_read is True
+            assert messages[1].content == "Hello User!" and messages[1].is_read is False
+            assert messages[2].content == "Old bot message" and messages[2].is_read is True
+            logging.info(f"Retrieved {len(messages)} messages for conversation {conv.id}")
+
+            # Test mark_messages_as_read
+            logging.info(f"Marking messages as read for conversation {conv.id}")
+            marked_count = mark_messages_as_read(db, conv.id)
+            assert marked_count == 1 # Only msg2 should have been marked read
+
+            messages_after_mark = get_messages_for_conversation(db, conv.id)
+            for m in messages_after_mark:
+                assert m.is_read is True
+            logging.info(f"All messages in conversation {conv.id} are now marked read.")
+
+            # Test marking again when no unread messages
+            marked_count_again = mark_messages_as_read(db, conv.id)
+            assert marked_count_again == 0
+
+
+            # Get message by Botpress ID
+            retrieved_msg1 = get_message_by_botpress_id(db, BP_MSG_ID_TEST_1)
+            assert retrieved_msg1 is not None and retrieved_msg1.id == msg1.id
+            logging.info(f"Retrieved message by BP ID '{BP_MSG_ID_TEST_1}': {retrieved_msg1}")
+
+            # Update conversation status
+            updated_conv = update_conversation_status(db, conv.id, "archived")
+            assert updated_conv is not None and updated_conv.status == "archived"
+            logging.info(f"Updated conversation status to '{updated_conv.status}'")
+
+            # Update conversation timestamp explicitly
+            new_timestamp = datetime.utcnow()
+            updated_conv_ts = update_conversation_timestamp(db, conv.id, new_timestamp)
+            assert updated_conv_ts is not None
+            assert abs((updated_conv_ts.last_message_timestamp - new_timestamp).total_seconds()) < 1
+            logging.info(f"Updated conversation timestamp to: {updated_conv_ts.last_message_timestamp}")
+
+            # Get recent conversations
+            recent_convs = get_recent_conversations(db, limit=5)
+            assert len(recent_convs) > 0
+            assert recent_convs[0].id == conv.id # Assuming this is the most recent
+            logging.info(f"Retrieved {len(recent_convs)} recent conversations. Most recent: {recent_convs[0]}")
+
+            # Test count_unread_bot_messages
+            logging.info("\n--- Testing count_unread_bot_messages ---")
+            # At this point, all messages in 'conv' are read.
+            # Add a new conversation with unread bot messages
+            conv_unread_test = get_or_create_conversation(db, "conv_unread_test")
+            add_message(db, conv_unread_test.id, "bot", "Unread bot msg 1", datetime.utcnow(), is_read=False)
+            add_message(db, conv_unread_test.id, "agent", "Unread agent msg", datetime.utcnow(), is_read=False)
+            add_message(db, conv_unread_test.id, "user", "User msg (read)", datetime.utcnow(), is_read=True)
+            add_message(db, conv_unread_test.id, "bot", "Another unread bot msg", datetime.utcnow()) # is_read defaults to False for bot
+
+            unread_bot_count = count_unread_bot_messages(db)
+            # Should be 3: "Unread bot msg 1", "Unread agent msg", "Another unread bot msg"
+            assert unread_bot_count == 3, f"Expected 3 unread bot/agent messages, got {unread_bot_count}"
+            logging.info(f"Found {unread_bot_count} unread non-user messages globally.")
+
+            # Mark them as read in that specific conversation to test count decrease
+            mark_messages_as_read(db, conv_unread_test.id)
+            unread_bot_count_after_read = count_unread_bot_messages(db)
+             # Assuming no other unread bot messages exist in other convos from previous tests
+            assert unread_bot_count_after_read == 0, f"Expected 0 unread bot/agent messages after marking, got {unread_bot_count_after_read}"
+            logging.info(f"After marking, found {unread_bot_count_after_read} unread non-user messages globally.")
+
+
+            logging.info("\n--- Conversation and Message CRUD tests completed successfully. ---")
+
+        except SQLAlchemyError as e:
+            logging.error(f"A SQLAlchemyError occurred during __main__ tests in crud.py: {e}", exc_info=True)
+            db.rollback()
+        except AssertionError as e:
+            logging.error(f"An assertion failed during __main__ tests in crud.py: {e}", exc_info=True)
+            db.rollback()
+        except Exception as e:
+            logging.error(f"An unexpected error occurred during __main__ tests in crud.py: {e}", exc_info=True)
+            db.rollback()
+        finally:
+            # Final cleanup
+            try:
+                logging.info(f"--- Final Cleanup of Test Data ---")
+                if 'conv' in locals() and conv and conv.id is not None : # Check if conv was defined and has an id
+                    messages_to_delete = get_messages_for_conversation(db, conv.id, limit=1000) # high limit
+                    for msg in messages_to_delete:
+                        db.delete(msg)
+                    db.commit()
+                    # Re-fetch conversation to delete, as session might have been rolled back
+                    conv_to_delete = db.query(models.Conversation).filter(models.Conversation.id == conv.id).first()
+                    if conv_to_delete:
+                        db.delete(conv_to_delete)
+                        db.commit()
+                        logging.info(f"Cleaned up conversation and messages for BP ID {BP_CONV_ID_TEST}")
+
+                delete_botpress_settings(db, USER_ID_TEST)
+                logging.info(f"Cleaned up settings for user: {USER_ID_TEST}")
+            except Exception as e:
+                logging.error(f"Failed to clean up all data post-test: {e}", exc_info=True)
+                db.rollback()
 
             if db:
                 db.close()

--- a/botpress_integration/models.py
+++ b/botpress_integration/models.py
@@ -1,6 +1,7 @@
-from sqlalchemy import create_engine, Column, Integer, String, ForeignKey, Text
+from sqlalchemy import create_engine, Column, Integer, String, ForeignKey, Text, DateTime, Boolean
 from sqlalchemy.ext.declarative import declarative_base
 from sqlalchemy.orm import sessionmaker, relationship
+from datetime import datetime
 
 DATABASE_URL = "sqlite:///./botpress_integration.db"  # Example SQLite URL
 
@@ -14,13 +15,14 @@ class UserBotpressSettings(Base):
     api_key = Column(String, nullable=False)
     bot_id = Column(String, nullable=False)
     preferred_language = Column(String, default="en")
+    base_url = Column(String, nullable=True) # For self-hosted instances
     # Add other relevant settings here
     # example_setting = Column(String)
 
     prompts = relationship("UserPrompt", back_populates="settings")
 
     def __repr__(self):
-        return f"<UserBotpressSettings(user_id='{self.user_id}', bot_id='{self.bot_id}')>"
+        return f"<UserBotpressSettings(user_id='{self.user_id}', bot_id='{self.bot_id}', base_url='{self.base_url}')>"
 
 class UserPrompt(Base):
     __tablename__ = "user_prompts"
@@ -72,3 +74,114 @@ if __name__ == "__main__":
     #     for prompt in retrieved_setting.prompts:
     #         print(f"  - Prompt: {prompt.prompt_name} - {prompt.prompt_text}")
     # db.close()
+
+class Conversation(Base):
+    __tablename__ = "conversations"
+
+    id = Column(Integer, primary_key=True, index=True)
+    botpress_conversation_id = Column(String, unique=True, index=True, nullable=False)
+    channel_type = Column(String, nullable=True)  # e.g., 'whatsapp', 'messenger', 'web'
+    user_identifier_on_channel = Column(String, nullable=True)
+    last_message_timestamp = Column(DateTime, nullable=True, index=True)
+    status = Column(String, default='active', nullable=False)  # e.g., 'active', 'archived', 'closed'
+
+    messages = relationship("Message", back_populates="conversation", cascade="all, delete-orphan")
+
+    def __repr__(self):
+        return f"<Conversation(id={self.id}, botpress_conversation_id='{self.botpress_conversation_id}', status='{self.status}')>"
+
+class Message(Base):
+    __tablename__ = "messages"
+
+    id = Column(Integer, primary_key=True, index=True)
+    conversation_id = Column(Integer, ForeignKey("conversations.id"), nullable=False)
+    botpress_message_id = Column(String, unique=True, index=True, nullable=True) # Nullable if purely local
+    sender_type = Column(String, nullable=False)  # e.g., 'user', 'bot', 'agent'
+    content = Column(Text, nullable=False)
+    timestamp = Column(DateTime, nullable=False, index=True, default=datetime.utcnow)
+    suggestions = Column(Text, nullable=True)  # Store JSON string of suggestions
+    is_read = Column(Boolean, default=False, nullable=False, index=True)
+
+    conversation = relationship("Conversation", back_populates="messages")
+
+    def __repr__(self):
+        return f"<Message(id={self.id}, sender_type='{self.sender_type}', timestamp='{self.timestamp}', is_read={self.is_read})>"
+
+if __name__ == "__main__":
+    # This will create the database and tables when models.py is run directly
+    create_db_and_tables()
+    print("Database and tables created (if they didn't exist).")
+
+    # Example of how to use the models (optional, for testing)
+    from sqlalchemy.orm import Session
+    db: Session = SessionLocal()
+
+    # Clean up existing test data for a fresh run
+    db.query(Message).delete()
+    db.query(Conversation).delete()
+    db.query(UserPrompt).delete()
+    db.query(UserBotpressSettings).delete()
+    db.commit()
+    print("Cleared existing test data.")
+
+    # Create a new setting
+    new_setting = UserBotpressSettings(user_id="user_conv_test", api_key="test_key", bot_id="test_bot", base_url="http://localhost:3000/api/v1")
+    db.add(new_setting)
+    db.commit()
+    db.refresh(new_setting)
+    print(f"Created setting: {new_setting}")
+
+    # Create a new conversation
+    new_conversation = Conversation(
+        botpress_conversation_id="bp_conv_123",
+        channel_type="web",
+        user_identifier_on_channel="visitor_xyz",
+        last_message_timestamp=datetime.utcnow(),
+        status="active"
+    )
+    db.add(new_conversation)
+    db.commit()
+    db.refresh(new_conversation)
+    print(f"Created conversation: {new_conversation}")
+
+    # Add messages to the conversation
+    message1 = Message(
+        conversation_id=new_conversation.id,
+        botpress_message_id="bp_msg_abc",
+        sender_type="user",
+        content="Hello, I need help!",
+        timestamp=datetime.utcnow(),
+        is_read=True # User messages are read by default
+    )
+    db.add(message1)
+
+    message2 = Message(
+        conversation_id=new_conversation.id,
+        sender_type="bot",
+        content="Hello! How can I assist you today?",
+        timestamp=datetime.utcnow(), # Botpress message ID might be null if bot initiated locally
+        is_read=False # Bot messages are unread by default
+    )
+    db.add(message2)
+    db.commit()
+    db.refresh(message1)
+    db.refresh(message2)
+    print(f"Added message: {message1}")
+    print(f"Added message: {message2}")
+
+    # Query the conversation and its messages
+    retrieved_conv = db.query(Conversation).filter(Conversation.botpress_conversation_id == "bp_conv_123").first()
+    if retrieved_conv:
+        print(f"\nRetrieved conversation: {retrieved_conv}")
+        print(f"  Status: {retrieved_conv.status}")
+        print(f"  Last message at: {retrieved_conv.last_message_timestamp}")
+        print(f"  Messages ({len(retrieved_conv.messages)}):")
+        for msg in retrieved_conv.messages:
+            print(f"    - [{msg.sender_type} at {msg.timestamp.strftime('%Y-%m-%d %H:%M:%S')}]: {msg.content[:50]}...")
+
+    # Example of querying a message by its Botpress ID
+    retrieved_msg = db.query(Message).filter(Message.botpress_message_id == "bp_msg_abc").first()
+    if retrieved_msg:
+        print(f"\nRetrieved message by Botpress ID 'bp_msg_abc': {retrieved_msg.content}")
+
+    db.close()

--- a/botpress_integration/ui_components.py
+++ b/botpress_integration/ui_components.py
@@ -3,25 +3,38 @@ import logging
 from PyQt5.QtWidgets import (
     QApplication, QWidget, QVBoxLayout, QHBoxLayout, QLabel, QLineEdit,
     QTextEdit, QPushButton, QGroupBox, QMessageBox, QListWidget, QInputDialog,
-    QListWidgetItem
+    QListWidgetItem, QSplitter, QScrollArea, QSystemTrayIcon, QStyle
 )
-from PyQt5.QtCore import Qt
+from PyQt5.QtGui import QIcon # Added for QSystemTrayIcon
+from PyQt5.QtCore import Qt, QItemSelectionModel, QTimer, QFile, QUrl # Added QTimer, QFile, QUrl
+# Optional for sound:
+# from PyQt5.QtMultimedia import QSoundEffect
 
+import json
+from datetime import datetime
 # Project specific imports - adjust path if necessary
-from .api_client import BotpressClient, BotpressAPIError # Import custom API error
+from .api_client import BotpressClient, BotpressAPIError
 from .crud import (
     get_botpress_settings, create_or_update_botpress_settings,
-    get_prompts_for_user, create_user_prompt, update_user_prompt, delete_user_prompt
-    # get_prompt_by_name is used internally by CRUD, not directly here.
+    get_prompts_for_user, create_user_prompt, update_user_prompt, delete_user_prompt,
+    get_or_create_conversation, add_message, get_messages_for_conversation,
+    update_conversation_timestamp, get_conversation_by_botpress_id,
+    count_unread_bot_messages, has_unread_bot_messages, mark_messages_as_read # Added new crud functions
 )
-from .models import SessionLocal, create_db_and_tables, UserPrompt # UserPrompt needed for type hint / query in edit
-from sqlalchemy.exc import SQLAlchemyError # Import for DB error handling
+from .models import SessionLocal, create_db_and_tables, UserPrompt, Conversation, Message
+from sqlalchemy.exc import SQLAlchemyError
 
 # Setup basic logging if not already configured by the main application
 # This is good practice for module independence.
 # In a larger app, the main entry point would usually configure logging.
 if not logging.getLogger().handlers:
     logging.basicConfig(level=logging.INFO, format='%(asctime)s - %(levelname)s - %(name)s - %(message)s')
+
+# Constants for QListWidgetItem data roles
+CONVO_ID_ROLE = Qt.UserRole
+BP_CONVO_ID_ROLE = Qt.UserRole + 1
+IS_UNREAD_ROLE = Qt.UserRole + 2
+
 
 class BotpressIntegrationUI(QWidget):
     def __init__(self, parent=None, current_user_id=None):
@@ -38,8 +51,41 @@ class BotpressIntegrationUI(QWidget):
             # For now, rely on later checks in methods like load_settings.
 
         self.botpress_client = None
-        self.db_session = None # Initialize later to handle potential DB connection errors
+        self.db_session = None
         self.current_settings_id = None
+        self.current_db_conversation_id = None
+        self.current_botpress_conversation_id = "default"
+        self.has_unread_bot_messages = False # For polling state
+
+        self.notification_timer = QTimer(self)
+        self.notification_timer.timeout.connect(self.check_for_new_messages)
+
+        # Initialize QSystemTrayIcon
+        self.tray_icon = QSystemTrayIcon(self)
+        icon_path = "icons/logo.svg" # Consider making this configurable or part of resources
+        if QFile.exists(icon_path):
+            self.tray_icon.setIcon(QIcon(icon_path))
+        else:
+            standard_icon = self.style().standardIcon(QStyle.SP_MessageBoxInformation) # Fallback icon
+            self.tray_icon.setIcon(standard_icon)
+            self.logger.warning(f"Custom tray icon not found at {icon_path}, using standard icon.")
+
+        if QSystemTrayIcon.isSystemTrayAvailable():
+            self.tray_icon.show()
+            self.tray_icon.activated.connect(self.handle_tray_icon_activated)
+            self.logger.info("System tray icon initialized and shown.")
+        else:
+            self.logger.warning("System tray not available on this system.")
+            # self.tray_icon will exist but won't be shown. Methods using it should check isVisible().
+
+        # Optional Sound Setup (ensure sound file exists or handle gracefully)
+        # self.notification_sound = QSoundEffect(self)
+        # sound_file_path = "assets/notification.wav"
+        # if QFile.exists(sound_file_path):
+        #     self.notification_sound.setSource(QUrl.fromLocalFile(sound_file_path))
+        # else:
+        #     self.logger.warning(f"Notification sound file not found at {sound_file_path}")
+
 
         try:
             # Ensure DB schema is created (idempotent)
@@ -68,7 +114,23 @@ class BotpressIntegrationUI(QWidget):
 
     def init_ui(self):
         self.logger.debug("Initializing UI components.")
-        main_layout = QVBoxLayout(self)
+        top_level_layout = QVBoxLayout(self) # This will be the actual main layout for the QWidget
+
+        # Main application layout will be a QHBoxLayout inside a QSplitter for resizable areas
+        main_splitter = QSplitter(Qt.Horizontal)
+
+        # --- Left Panel: Conversations List ---
+        conversations_group = QGroupBox("Recent Conversations")
+        conversations_panel_layout = QVBoxLayout() # Layout for the group box
+        self.conversations_list_widget = QListWidget()
+        self.conversations_list_widget.currentItemChanged.connect(self.handle_conversation_selected)
+        conversations_panel_layout.addWidget(self.conversations_list_widget)
+        conversations_group.setLayout(conversations_panel_layout)
+        main_splitter.addWidget(conversations_group)
+
+        # --- Right Panel: Main Chat and Settings Area ---
+        chat_and_settings_widget = QWidget()
+        right_panel_layout = QVBoxLayout(chat_and_settings_widget)
 
         # API Configuration
         api_group = QGroupBox("API Configuration")
@@ -84,6 +146,11 @@ class BotpressIntegrationUI(QWidget):
         api_layout.addWidget(QLabel("Bot ID:"))
         api_layout.addWidget(self.bot_id_input)
 
+        api_layout.addWidget(QLabel("Botpress Base URL (leave empty for default cloud):"))
+        self.base_url_input = QLineEdit()
+        self.base_url_input.setPlaceholderText("https://api.botpress.cloud/v1/")
+        api_layout.addWidget(self.base_url_input)
+
         config_buttons_layout = QHBoxLayout()
         self.load_settings_button = QPushButton("Load Settings")
         self.load_settings_button.clicked.connect(self.load_settings)
@@ -95,16 +162,22 @@ class BotpressIntegrationUI(QWidget):
         api_layout.addLayout(config_buttons_layout)
 
         api_group.setLayout(api_layout)
-        main_layout.addWidget(api_group)
+        right_panel_layout.addWidget(api_group)
 
-        # Conversation Display
+        # Conversation Display (Refactored with QScrollArea)
         conversation_group = QGroupBox("Conversation")
-        conversation_layout = QVBoxLayout()
-        self.conversation_display = QTextEdit()
-        self.conversation_display.setReadOnly(True)
-        conversation_layout.addWidget(self.conversation_display)
-        conversation_group.setLayout(conversation_layout)
-        main_layout.addWidget(conversation_group)
+        conversation_group_layout = QVBoxLayout(conversation_group) # Layout for the GroupBox
+
+        self.conversation_scroll_area = QScrollArea()
+        self.conversation_scroll_area.setWidgetResizable(True)
+
+        self.conversation_widget = QWidget() # This widget will contain the messages
+        self.conversation_layout = QVBoxLayout(self.conversation_widget) # Add messages to this layout
+        self.conversation_layout.setAlignment(Qt.AlignTop) # Messages stack from top
+
+        self.conversation_scroll_area.setWidget(self.conversation_widget)
+        conversation_group_layout.addWidget(self.conversation_scroll_area)
+        right_panel_layout.addWidget(conversation_group)
 
         # Message Input
         message_input_layout = QHBoxLayout()
@@ -115,16 +188,14 @@ class BotpressIntegrationUI(QWidget):
         self.send_button = QPushButton("Send")
         self.send_button.clicked.connect(self.handle_send_message)
         message_input_layout.addWidget(self.send_button)
-        main_layout.addLayout(message_input_layout)
+        right_panel_layout.addLayout(message_input_layout)
 
         # Prompts Management
         prompts_group = QGroupBox("Prompts Management")
-        prompts_main_layout = QVBoxLayout() # Main layout for this group
-
+        prompts_main_layout = QVBoxLayout()
         self.prompts_list_widget = QListWidget()
-        self.prompts_list_widget.itemDoubleClicked.connect(self.edit_selected_prompt) # Edit on double click
+        self.prompts_list_widget.itemDoubleClicked.connect(self.edit_selected_prompt)
         prompts_main_layout.addWidget(self.prompts_list_widget)
-
         prompts_buttons_layout = QHBoxLayout()
         self.add_prompt_button = QPushButton("Add Prompt")
         self.add_prompt_button.clicked.connect(self.add_prompt)
@@ -135,12 +206,16 @@ class BotpressIntegrationUI(QWidget):
         self.delete_prompt_button = QPushButton("Delete Prompt")
         self.delete_prompt_button.clicked.connect(self.delete_selected_prompt)
         prompts_buttons_layout.addWidget(self.delete_prompt_button)
-
         prompts_main_layout.addLayout(prompts_buttons_layout)
         prompts_group.setLayout(prompts_main_layout)
-        main_layout.addWidget(prompts_group)
+        right_panel_layout.addWidget(prompts_group)
 
-        self.setLayout(main_layout)
+        main_splitter.addWidget(chat_and_settings_widget)
+        main_splitter.setStretchFactor(0, 1) # Conversation list less space
+        main_splitter.setStretchFactor(1, 3) # Chat area more space
+
+        top_level_layout.addWidget(main_splitter)
+        # self.setLayout(top_level_layout) # Already set by QVBoxLayout(self)
 
     def load_settings(self):
         if not self.db_session:
@@ -159,34 +234,71 @@ class BotpressIntegrationUI(QWidget):
             if settings:
                 self.api_key_input.setText(settings.api_key)
                 self.bot_id_input.setText(settings.bot_id)
+                stored_base_url = settings.base_url
+                self.base_url_input.setText(stored_base_url if stored_base_url else "https://api.botpress.cloud/v1/")
                 self.current_settings_id = settings.id
-                self.logger.info(f"Settings found for user {self.current_user_id}. Settings ID: {self.current_settings_id}")
+                self.logger.info(f"Settings found for user {self.current_user_id}. Settings ID: {self.current_settings_id}, Base URL: {stored_base_url}")
+
                 try:
-                    self.botpress_client = BotpressClient(api_key=settings.api_key, bot_id=settings.bot_id)
-                    QMessageBox.information(self, "Settings Loaded", "API settings loaded and Botpress client initialized.")
-                    self.conversation_display.append("<i>API Client initialized. Ready to chat.</i>")
-                    self.load_conversation_history()
+                    api_url_to_use = stored_base_url if stored_base_url else "https://api.botpress.cloud/v1/"
+                    self.botpress_client = BotpressClient(api_key=settings.api_key, bot_id=settings.bot_id, base_url=api_url_to_use)
+                    self.clear_conversation_display()
+                    self.add_message_to_display("system", f"API Client initialized (URL: {api_url_to_use}).", datetime.now())
+
+                    # Determine a default/initial Botpress conversation ID.
+                    initial_bp_conversation_id = f"{settings.bot_id}_main_chat"
+
+                    db_conversation = get_or_create_conversation(
+                        self.db_session,
+                        botpress_conversation_id=initial_bp_conversation_id
+                    )
+                    self.current_db_conversation_id = db_conversation.id
+                    self.current_botpress_conversation_id = db_conversation.botpress_conversation_id
+
+                    self.logger.info(f"Default/Initial local DB conversation set: ID={self.current_db_conversation_id}, BP_ID='{self.current_botpress_conversation_id}'")
+                    self.add_message_to_display("system", f"Default Botpress Conversation ID: {self.current_botpress_conversation_id}", datetime.now())
+
                     self.load_prompts()
-                except Exception as e: # Catch errors from BotpressClient instantiation (e.g. bad URL if not mock)
-                    self.logger.error(f"Failed to initialize Botpress client after loading settings: {e}", exc_info=True)
-                    QMessageBox.critical(self, "API Client Error", f"Failed to initialize Botpress client: {e}")
+                    self.load_and_display_recent_conversations() # This will also trigger selection and history load
+
+                    self.notification_timer.start(15000) # Start polling
+                    self.check_for_new_messages() # Initial check
+
+                except SQLAlchemyError as dbe:
+                    self.logger.error(f"Database error setting up conversation: {dbe}", exc_info=True)
+                    QMessageBox.critical(self, "DB Conversation Error", f"Failed to setup local conversation: {dbe}")
+                except Exception as e:
+                    self.logger.error(f"Failed to initialize Botpress client or setup conversation: {e}", exc_info=True)
+                    QMessageBox.critical(self, "API Client/Conversation Error", f"Failed to initialize Botpress client or setup conversation: {e}")
                     self.botpress_client = None
+                    self.current_db_conversation_id = None
+                    self.notification_timer.stop()
             else:
                 self.logger.info(f"No settings found for user {self.current_user_id}. Clearing fields.")
                 QMessageBox.information(self, "No Settings", "No API settings found for this user. Please configure.")
                 self.api_key_input.clear()
                 self.bot_id_input.clear()
+                self.base_url_input.setText("https://api.botpress.cloud/v1/")
                 self.botpress_client = None
                 self.current_settings_id = None
+                self.current_db_conversation_id = None
+                self.current_botpress_conversation_id = "default"
                 self.prompts_list_widget.clear()
+                self.conversations_list_widget.clear()
+                self.clear_conversation_display()
+                self.notification_timer.stop()
         except SQLAlchemyError as e:
             self.logger.error(f"Database error while loading settings for user {self.current_user_id}: {e}", exc_info=True)
             QMessageBox.critical(self, "Database Error", f"Error loading settings: {e}. Check logs.")
-            self.botpress_client = None # Ensure client is None on DB error
-        except Exception as e: # Catch any other unexpected errors
+            self.botpress_client = None
+            self.current_db_conversation_id = None
+            self.notification_timer.stop()
+        except Exception as e:
             self.logger.error(f"Unexpected error while loading settings: {e}", exc_info=True)
             QMessageBox.critical(self, "Unexpected Error", f"An unexpected error occurred: {e}. Check logs.")
             self.botpress_client = None
+            self.current_db_conversation_id = None
+            self.notification_timer.stop()
 
 
     def save_settings(self):
@@ -202,91 +314,496 @@ class BotpressIntegrationUI(QWidget):
 
         api_key = self.api_key_input.text().strip()
         bot_id = self.bot_id_input.text().strip()
+        input_base_url = self.base_url_input.text().strip()
 
         if not api_key or not bot_id:
             QMessageBox.warning(self, "Input Error", "API Key and Bot ID cannot be empty.")
             return
 
-        self.logger.info(f"Saving settings for user_id: {self.current_user_id}")
+        base_url_to_save = input_base_url if input_base_url else None # Save None if field is empty
+
+        self.logger.info(f"Saving settings for user_id: {self.current_user_id} with base_url: {base_url_to_save}")
         try:
             settings = create_or_update_botpress_settings(
                 self.db_session,
                 user_id=self.current_user_id,
                 api_key=api_key,
-                bot_id=bot_id
+                bot_id=bot_id,
+                base_url=base_url_to_save
             )
             self.current_settings_id = settings.id
-            self.botpress_client = BotpressClient(api_key=api_key, bot_id=bot_id) # Re-initialize client
+
+            api_url_to_use = input_base_url if input_base_url else "https://api.botpress.cloud/v1/"
+            self.botpress_client = BotpressClient(api_key=api_key, bot_id=bot_id, base_url=api_url_to_use)
+
             QMessageBox.information(self, "Settings Saved", "API settings saved and client re-initialized.")
-            self.conversation_display.append("<i>API Client re-initialized with new settings.</i>")
-            self.logger.info(f"Settings saved successfully for user {self.current_user_id}. New settings_id: {self.current_settings_id}")
-            self.load_prompts() # Refresh prompts list as settings_id might be new
+            self.add_message_to_display("system", f"API Client re-initialized (URL: {api_url_to_use}).", datetime.now())
+            self.logger.info(f"Settings saved successfully for user {self.current_user_id}. Settings ID: {self.current_settings_id}, Base URL used: {api_url_to_use}")
+            self.load_prompts()
+            self.load_and_display_recent_conversations()
+            self.notification_timer.start(15000) # Restart polling with new settings
+            self.check_for_new_messages()
         except SQLAlchemyError as e:
             self.logger.error(f"Database error saving settings for user {self.current_user_id}: {e}", exc_info=True)
             QMessageBox.critical(self, "Database Error", f"Failed to save settings due to database error: {e}. Check logs.")
-            # self.botpress_client might be in an inconsistent state if it was initialized before commit failed.
-            # Best to set it to None or try to reload previous valid settings. For now, set to None.
             self.botpress_client = None
-        except Exception as e: # Catch errors from BotpressClient instantiation or other issues
+            self.notification_timer.stop()
+        except Exception as e:
             self.logger.error(f"Error saving settings or initializing client for user {self.current_user_id}: {e}", exc_info=True)
             QMessageBox.critical(self, "Save Error", f"Failed to save settings: {e}. Check logs.")
             self.botpress_client = None
+            self.notification_timer.stop()
 
 
     def handle_send_message(self):
         self.logger.debug("handle_send_message called.")
-        if not self.botpress_client:
-            QMessageBox.warning(self, "Client Not Ready", "Botpress client is not initialized. Please check API settings and load them.")
-            self.logger.warning("handle_send_message: Botpress client not initialized.")
+        if not self.botpress_client or not self.db_session or not self.current_db_conversation_id:
+            QMessageBox.warning(self, "Client/DB Not Ready",
+                                "Botpress client, DB session, or active conversation not properly initialized. "
+                                "Please check API settings and load them.")
+            self.logger.warning(f"handle_send_message: Client/DB/Conversation not ready. Client: {self.botpress_client}, DB: {self.db_session}, DBConvID: {self.current_db_conversation_id}")
             return
 
-        user_message = self.message_input.text().strip()
-        if not user_message:
+        user_message_text = self.message_input.text().strip()
+        if not user_message_text:
             return
 
-        self.conversation_display.append(f"<b>You:</b> {user_message}")
-        self.logger.info(f"User sending message: {user_message}")
+        # 1. Save user message to local DB and display
         try:
-            response = self.botpress_client.send_message(user_message)
-            self.conversation_display.append(f"<b>Bot:</b> {response}")
-            self.logger.info(f"Bot response received: {response}")
-        except BotpressAPIError as e: # Catch custom API errors first
-            self.logger.error(f"Botpress API error sending message: {e}", exc_info=True)
-            QMessageBox.critical(self, "API Error", f"Botpress API error: {e}")
-            self.conversation_display.append(f"<i>API Error: {e}</i>")
-        except Exception as e: # Catch other errors like ConnectionError from requests
-            self.logger.error(f"Error sending message via Botpress client: {e}", exc_info=True)
-            QMessageBox.critical(self, "Send Error", f"Failed to send message: {e}")
-            self.conversation_display.append(f"<i>Error sending message: {e}</i>")
+            timestamp = datetime.now()
+            # Don't save user message to DB yet, do it after successful API call or based on exact requirements
+            # For now, display immediately, save after API success or if API fails but we still want to log user part.
+            self.add_message_to_display(sender_type='user', text=user_message_text, timestamp=timestamp)
+            self.logger.info(f"User attempting to send message: {user_message_text}")
+        except Exception as e: # Should not happen with simple display, but good for robustness
+            self.logger.error(f"Error displaying user message: {e}", exc_info=True)
+            QMessageBox.critical(self, "Display Error", f"Failed to display your message: {e}")
+            return
 
-        self.message_input.clear()
-        self.conversation_display.verticalScrollBar().setValue(self.conversation_display.verticalScrollBar().maximum())
+        # 2. Send message via API client
+        try:
+            # Save user message to DB before sending
+            db_user_message = add_message(self.db_session,
+                                          conversation_id=self.current_db_conversation_id,
+                                          sender_type='user',
+                                          content=user_message_text,
+                                          timestamp=timestamp) # Use same timestamp as display
+            self.logger.info(f"User message '{user_message_text}' saved to DB with ID {db_user_message.id}")
+
+            response_data = self.botpress_client.send_message(user_message_text, conversation_id=self.current_botpress_conversation_id)
+            self.logger.info(f"Botpress API response: {response_data}")
+
+            bot_messages_in_response = []
+            # Botpress might send an array of messages in response to one user message
+            # Example: {"responses": [{"type": "text", "text": "Hi!", "suggestions": [...]}, {"type": "typing", "value": true}]}
+            # We are interested in messages of type "text" or that have a "text" field.
+            # The key might be "message", "messages", or "responses". Adjust based on actual API.
+            # For this example, let's assume the structure from the task description for a single message:
+            # response_data = {"id": "msg_api_123", "conversationId": "conv_xyz", "text": "...", "suggestions": [...]}
+            # Or if it's a list under a key, e.g. response_data["messages"]
+
+            potential_message_holders = []
+            if isinstance(response_data, list): # If the root is a list of messages
+                potential_message_holders = response_data
+            elif isinstance(response_data, dict):
+                if "message" in response_data and isinstance(response_data["message"], dict):
+                    potential_message_holders.append(response_data["message"])
+                elif "messages" in response_data and isinstance(response_data["messages"], list):
+                    potential_message_holders.extend(response_data["messages"])
+                elif "responses" in response_data and isinstance(response_data["responses"], list): # Another common pattern
+                    potential_message_holders.extend(response_data["responses"])
+                elif "text" in response_data : # If the root object is a single message
+                     potential_message_holders.append(response_data)
+
+
+            if not potential_message_holders:
+                 self.logger.warning(f"No processable message objects found in Botpress response: {response_data}")
+                 self.add_message_to_display("system", f"Bot response structure not recognized or empty: {str(response_data)[:100]}", datetime.now())
+
+            for bot_msg_payload in potential_message_holders:
+                # Skip if not a message type we can display (e.g. typing indicators)
+                if bot_msg_payload.get("type") not in [None, "text", "message"] and not bot_msg_payload.get("text"):
+                    self.logger.info(f"Skipping non-text/non-message payload: {bot_msg_payload.get('type')}")
+                    continue
+
+                bot_reply_text = bot_msg_payload.get("text", "Bot sent an empty message.")
+                bot_message_api_id = bot_msg_payload.get("id")
+                response_conversation_id = bot_msg_payload.get("conversationId")
+                api_suggestions_list = bot_msg_payload.get("suggestions")
+                suggestions_json_to_save = None
+                if api_suggestions_list and isinstance(api_suggestions_list, list):
+                    try:
+                        suggestions_json_to_save = json.dumps(api_suggestions_list)
+                    except TypeError:
+                        self.logger.error("Failed to serialize suggestions to JSON.", exc_info=True)
+
+                if response_conversation_id and response_conversation_id != self.current_botpress_conversation_id:
+                    self.logger.info(f"Botpress conversation ID changed from '{self.current_botpress_conversation_id}' to '{response_conversation_id}'. Updating.")
+                    self.current_botpress_conversation_id = response_conversation_id
+                    try:
+                        local_conv = self.db_session.query(Conversation).filter(Conversation.id == self.current_db_conversation_id).first()
+                        if local_conv:
+                            local_conv.botpress_conversation_id = response_conversation_id
+                            self.db_session.commit()
+                            self.logger.info(f"Updated local DB conversation {self.current_db_conversation_id} with new BP_ID {response_conversation_id}")
+                    except SQLAlchemyError as e:
+                        self.logger.error(f"DB error updating botpress_conversation_id for local conv {self.current_db_conversation_id}: {e}", exc_info=True)
+
+                bot_timestamp = datetime.now()
+                add_message(self.db_session,
+                            conversation_id=self.current_db_conversation_id,
+                            sender_type='bot',
+                            content=bot_reply_text,
+                            timestamp=bot_timestamp,
+                            botpress_message_id=bot_message_api_id,
+                            suggestions=suggestions_json_to_save)
+                self.add_message_to_display(sender_type='bot', text=bot_reply_text, timestamp=bot_timestamp, suggestions=api_suggestions_list)
+                self.logger.info(f"Bot reply '{bot_reply_text}' (API ID: {bot_message_api_id}) saved to DB for conv_id {self.current_db_conversation_id}")
+
+        except BotpressAPIError as e:
+            self.logger.error(f"Botpress API error: {e}", exc_info=True)
+            QMessageBox.critical(self, "API Error", f"Botpress API error: {e}")
+            self.add_message_to_display("system", f"API Error: {e}", datetime.now())
+        except Exception as e:
+            self.logger.error(f"Error sending/receiving: {e}", exc_info=True)
+            QMessageBox.critical(self, "Processing Error", f"Error during send/receive: {e}")
+            self.add_message_to_display("system", f"Processing Error: {e}", datetime.now())
+        finally:
+            self.message_input.clear()
+            # Auto-scroll handled by add_message_to_display
+            self.load_and_display_recent_conversations()
+            self.restore_conversation_list_selection(self.current_db_conversation_id)
 
 
     def load_conversation_history(self):
-        self.logger.debug("load_conversation_history called.")
-        if not self.botpress_client:
-            self.logger.info("load_conversation_history: Botpress client not ready.")
-            # self.conversation_display.append("<i>Botpress client not initialized. Cannot load history.</i>")
+        self.logger.debug(f"load_conversation_history for DB ID: {self.current_db_conversation_id}, BP ID: {self.current_botpress_conversation_id}")
+        self.clear_conversation_display()
+        if not self.db_session:
+            self.logger.error("load_conversation_history: db_session is None.")
+            self.add_message_to_display("system", "Database session not available.", datetime.now())
             return
 
-        self.conversation_display.append("<i>Loading conversation history (mock)...</i>")
+        if not self.current_db_conversation_id:
+            self.logger.info("load_conversation_history: No active local DB conversation.")
+            self.add_message_to_display("system", "Select a conversation to view its history.", datetime.now())
+            return
+
+        self.add_message_to_display("system", f"Loading history for DB ID: {self.current_db_conversation_id} (BP ID: {self.current_botpress_conversation_id})...", datetime.now())
         try:
-            history = self.botpress_client.get_conversations() # Mock
-            for message in history:
-                sender = "Bot" if message.get("sender", "").lower() == "bot" else "User"
-                self.conversation_display.append(f"<b>{sender}:</b> {message.get('text', '')}")
-            self.conversation_display.append("<i>--- End of mock history ---</i>")
-            self.logger.info("Mock conversation history loaded.")
-        except BotpressAPIError as e:
-            self.logger.error(f"Botpress API error loading history: {e}", exc_info=True)
-            QMessageBox.critical(self, "API Error", f"Botpress API error loading history: {e}")
-            self.conversation_display.append(f"<i>API Error loading history: {e}</i>")
+            messages = get_messages_for_conversation(self.db_session,
+                                                     conversation_id=self.current_db_conversation_id,
+                                                     limit=100)
+            if not messages:
+                self.add_message_to_display("system", "No messages in this conversation yet.", datetime.now())
+            else:
+                for msg in messages:
+                    suggestions_list = None
+                    if msg.suggestions:
+                        try:
+                            suggestions_list = json.loads(msg.suggestions)
+                        except json.JSONDecodeError:
+                            self.logger.error(f"Failed to parse suggestions from DB for msg ID {msg.id}: {msg.suggestions}", exc_info=True)
+                    self.add_message_to_display(sender_type=msg.sender_type,
+                                                text=msg.content,
+                                                timestamp=msg.timestamp,
+                                                suggestions=suggestions_list)
+            self.logger.info(f"Loaded {len(messages)} messages for conv_id {self.current_db_conversation_id}")
+
+        except SQLAlchemyError as e:
+            self.logger.error(f"DB error loading history for conv_id {self.current_db_conversation_id}: {e}", exc_info=True)
+            QMessageBox.critical(self, "DB Error", f"Error loading history: {e}")
+            self.add_message_to_display("system", f"DB Error: {e}", datetime.now())
         except Exception as e:
-            self.logger.error(f"Error loading conversation history: {e}", exc_info=True)
-            QMessageBox.critical(self, "History Error", f"Failed to load conversation history: {e}")
-            self.conversation_display.append(f"<i>Error loading history: {e}</i>")
-        self.conversation_display.verticalScrollBar().setValue(self.conversation_display.verticalScrollBar().maximum())
+            self.logger.error(f"Unexpected error loading history: {e}", exc_info=True)
+            QMessageBox.critical(self, "History Error", f"Failed to load history: {e}")
+            self.add_message_to_display("system", f"Error: {e}", datetime.now())
+
+        # Auto-scroll handled by add_message_to_display
+
+    def load_and_display_recent_conversations(self):
+        self.logger.debug("Loading and displaying recent conversations.")
+        if not self.db_session:
+            self.logger.error("load_and_display_recent_conversations: db_session is None.")
+            return
+
+        current_selection_db_id = self.current_db_conversation_id # Preserve current selection
+
+        self.conversations_list_widget.clear()
+        try:
+            recent_convos = crud.get_recent_conversations(self.db_session, limit=25)
+            if not recent_convos:
+                self.conversations_list_widget.addItem("No recent conversations found.")
+                self.logger.info("No recent conversations found in DB.")
+            else:
+                for convo in recent_convos:
+                    last_msg_time_str = convo.last_message_timestamp.strftime('%Y-%m-%d %H:%M') if convo.last_message_timestamp else 'Never'
+                    display_text = f"{convo.botpress_conversation_id[:20]}... (Last: {last_msg_time_str})"
+
+                    item = QListWidgetItem() # Create item first
+                    item.setData(CONVO_ID_ROLE, convo.id)
+                    item.setData(BP_CONVO_ID_ROLE, convo.botpress_conversation_id)
+
+                    is_unread = crud.has_unread_bot_messages(self.db_session, convo.id)
+                    self.update_conversation_item_style(item, is_unread, base_text=display_text) # Use helper
+
+                    item.setToolTip(f"DB ID: {convo.id}\nBotpress ID: {convo.botpress_conversation_id}\nChannel: {convo.channel_type or 'N/A'}\nUser: {convo.user_identifier_on_channel or 'N/A'}\nStatus: {convo.status}")
+                    self.conversations_list_widget.addItem(item)
+                self.logger.info(f"Displayed {len(recent_convos)} recent conversations.")
+
+            if current_selection_db_id:
+                self.restore_conversation_list_selection(current_selection_db_id)
+            elif self.conversations_list_widget.count() > 0:
+                first_item = self.conversations_list_widget.item(0)
+                if first_item and first_item.data(CONVO_ID_ROLE) is not None:
+                    self.conversations_list_widget.setCurrentItem(first_item)
+                else:
+                    self.handle_conversation_selected(None, None)
+
+        except SQLAlchemyError as e:
+            self.logger.error(f"DB error loading recent conversations: {e}", exc_info=True)
+            QMessageBox.critical(self, "DB Error", f"Failed to load recent conversations: {e}")
+            self.conversations_list_widget.addItem("Error loading conversations.")
+
+    def update_conversation_item_style(self, item: QListWidgetItem, is_unread: bool, base_text: Optional[str] = None):
+        if not item: return
+        font = item.font()
+
+        # If base_text is not provided, try to get current text and strip previous markers
+        current_text = base_text
+        unread_marker = "[UNREAD] "
+        if current_text is None:
+            current_text = item.text()
+            if current_text.startswith(unread_marker):
+                current_text = current_text[len(unread_marker):]
+
+        if is_unread:
+            font.setBold(True)
+            if not current_text.startswith(unread_marker): # Avoid double marking
+                 item.setText(unread_marker + current_text)
+            else: # Already has marker, just ensure text is correct
+                 item.setText(unread_marker + current_text) # Use current_text which is stripped
+        else:
+            font.setBold(False)
+            if current_text.startswith(unread_marker): # Remove marker
+                item.setText(current_text[len(unread_marker):])
+            else:
+                item.setText(current_text) # Ensure it's the base text
+
+        item.setFont(font)
+        item.setData(IS_UNREAD_ROLE, is_unread)
+
+
+    def handle_conversation_selected(self, current_item, previous_item):
+        if not current_item or current_item.data(CONVO_ID_ROLE) is None:
+            self.current_db_conversation_id = None
+            self.current_botpress_conversation_id = "default"
+            self.clear_conversation_display()
+            self.add_message_to_display("system", "No conversation selected or conversation is empty.", datetime.now())
+            self.logger.info("No conversation selected or placeholder item selected.")
+            self.message_input.setEnabled(False)
+            self.send_button.setEnabled(False)
+            return
+
+        db_id = current_item.data(CONVO_ID_ROLE)
+        bp_convo_id = current_item.data(BP_CONVO_ID_ROLE)
+
+        self.current_db_conversation_id = db_id
+        self.current_botpress_conversation_id = bp_convo_id
+
+        self.logger.info(f"Switched to conversation DB ID: {db_id}, Botpress ID: {bp_convo_id}")
+        self.message_input.setEnabled(True)
+        self.send_button.setEnabled(True)
+        self.load_conversation_history() # This will display messages
+
+        # Mark messages as read for this conversation and update UI item
+        if self.db_session and self.current_db_conversation_id is not None:
+            try:
+                updated_count = crud.mark_messages_as_read(self.db_session, conversation_id=self.current_db_conversation_id)
+                if updated_count > 0:
+                    self.logger.info(f"Marked {updated_count} messages as read in conversation {self.current_db_conversation_id}.")
+                    self.update_conversation_item_style(current_item, False) # Update style to not bold
+                    # Potentially trigger a global unread count check for notifications, though this is on selection.
+                    self.check_for_new_messages()
+            except SQLAlchemyError as e:
+                self.logger.error(f"DB error marking messages as read for conv {self.current_db_conversation_id}: {e}", exc_info=True)
+
+
+    def restore_conversation_list_selection(self, db_conv_id_to_select):
+        if db_conv_id_to_select is None:
+            if self.conversations_list_widget.count() > 0:
+                first_item = self.conversations_list_widget.item(0)
+                if first_item and first_item.data(CONVO_ID_ROLE) is not None:
+                     self.conversations_list_widget.setCurrentItem(first_item)
+                else:
+                    self.handle_conversation_selected(None, None)
+            return
+
+        for i in range(self.conversations_list_widget.count()):
+            item = self.conversations_list_widget.item(i)
+            if item and item.data(CONVO_ID_ROLE) == db_conv_id_to_select:
+                self.conversations_list_widget.setCurrentItem(item)
+                self.logger.debug(f"Restored selection in list to conversation DB ID: {db_conv_id_to_select}")
+                return
+        self.logger.warning(f"Could not find conversation with DB ID {db_conv_id_to_select} in list to restore selection.")
+        if self.conversations_list_widget.count() > 0:
+            first_item = self.conversations_list_widget.item(0)
+            if first_item and first_item.data(CONVO_ID_ROLE) is not None:
+                self.conversations_list_widget.setCurrentItem(first_item)
+            else:
+                self.handle_conversation_selected(None, None)
+
+    def add_message_to_display(self, sender_type: str, text: str, timestamp: datetime, suggestions: Optional[list] = None):
+        """Adds a message widget to the conversation_layout with optional suggestion buttons."""
+
+        message_widget_container = QWidget() # Main container for this message entry
+        message_widget_layout = QVBoxLayout(message_widget_container)
+        message_widget_layout.setContentsMargins(5, 5, 5, 5) # Small margins around each message entry
+
+        # Create a QHBoxLayout to handle alignment (user right, bot left)
+        row_layout = QHBoxLayout()
+
+        timestamp_str = timestamp.strftime('%Y-%m-%d %H:%M:%S')
+        # Using QLabel with RichText for basic formatting like bold.
+        # For more complex styling (bubbles), custom painting or more complex HTML/CSS would be needed.
+        if sender_type.lower() == "system":
+             label_text = f"<i>System ({timestamp_str}): {text}</i>"
+        else:
+            label_text = f"<b>{sender_type.capitalize()}</b> ({timestamp_str}):<br>{text}"
+
+        message_label = QLabel(label_text)
+        message_label.setWordWrap(True)
+        message_label.setTextInteractionFlags(Qt.TextSelectableByMouse)
+        message_label.setStyleSheet("QLabel { padding: 5px; }") # Basic padding
+
+        if sender_type.lower() == 'user':
+            message_label.setStyleSheet("QLabel { background-color: #DCF8C6; border-radius: 5px; padding: 5px; }")
+            row_layout.addStretch()
+            row_layout.addWidget(message_label)
+        elif sender_type.lower() == 'bot':
+            message_label.setStyleSheet("QLabel { background-color: #ECECEC; border-radius: 5px; padding: 5px; }")
+            row_layout.addWidget(message_label)
+            row_layout.addStretch()
+        else: # System messages span full width or are left aligned
+            row_layout.addWidget(message_label)
+            # row_layout.addStretch() # Optional: if system messages should also be pushed left
+
+        message_widget_layout.addLayout(row_layout)
+
+        if suggestions and sender_type.lower() == 'bot': # Only show suggestions for bot messages
+            suggestions_container = QWidget()
+            suggestions_layout = QHBoxLayout(suggestions_container)
+            suggestions_layout.setAlignment(Qt.AlignLeft)
+            suggestions_layout.setContentsMargins(0, 5, 0, 0) # Margin above suggestions
+
+            for sugg in suggestions:
+                if isinstance(sugg, dict) and 'title' in sugg and 'payload' in sugg:
+                    button = QPushButton(sugg['title'])
+                    button.clicked.connect(lambda checked, p=sugg['payload'], mwc=message_widget_container: self.handle_suggestion_clicked(p, mwc))
+                    button.setCursor(Qt.PointingHandCursor)
+                    button.setStyleSheet("QPushButton { margin-right: 5px; }")
+                    suggestions_layout.addWidget(button)
+                else:
+                    self.logger.warning(f"Malformed suggestion item: {sugg}")
+
+            # Add a stretch to keep buttons packed left if there are few
+            suggestions_layout.addStretch()
+            message_widget_layout.addWidget(suggestions_container)
+
+        self.conversation_layout.addWidget(message_widget_container)
+
+        # Ensure scroll to bottom
+        QTimer.singleShot(0, lambda: self.conversation_scroll_area.verticalScrollBar().setValue(self.conversation_scroll_area.verticalScrollBar().maximum()))
+
+    def handle_suggestion_clicked(self, payload: str, message_widget_container_with_suggestions: QWidget):
+        """Handles click on a suggestion button."""
+        self.logger.info(f"Suggestion clicked with payload: '{payload}'")
+        self.message_input.setText(payload)
+        self.handle_send_message() # Auto-send the message
+
+        # Optional: Remove suggestion buttons from the specific message widget after click
+        # Find the suggestions_container within message_widget_container_with_suggestions and hide/delete it
+        # This assumes suggestions_container is the last widget added to message_widget_layout
+        message_widget_layout = message_widget_container_with_suggestions.layout()
+        if message_widget_layout and message_widget_layout.count() > 1: # Check if there's more than just the text label's layout
+            # Iterate backwards to find the suggestions_container, assuming it's the last one
+            # This is a bit fragile; a more robust way would be to name the widget.
+            potential_suggestions_widget = message_widget_layout.itemAt(message_widget_layout.count() -1).widget()
+            if potential_suggestions_widget and isinstance(potential_suggestions_widget.layout(), QHBoxLayout): # Heuristic
+                potential_suggestions_widget.hide() # Hide it
+                # potential_suggestions_widget.deleteLater() # Or delete it
+                self.logger.debug("Hid suggestion buttons after click.")
+
+
+    def clear_conversation_display(self):
+        """Clears all messages from the conversation display area."""
+        self.logger.debug("Clearing conversation display.")
+        while self.conversation_layout.count():
+            child = self.conversation_layout.takeAt(0)
+            if child.widget():
+                child.widget().deleteLater()
+        # Add a system message or leave blank
+        # self.add_message_to_display("system", "Conversation cleared.", datetime.now())
+
+    def check_for_new_messages(self):
+        if not self.db_session or not self.botpress_client:
+            return
+
+        try:
+            unread_count_globally = crud.count_unread_bot_messages(self.db_session)
+            if unread_count_globally > 0:
+                if not self.has_unread_bot_messages:
+                    self.logger.info(f"Polling: Found {unread_count_globally} new unread messages from non-user senders globally.")
+                    self.trigger_notifications(unread_count_globally)
+                self.has_unread_bot_messages = True
+                # Refresh conversation list to update bolding if any conversation's unread status changed
+                # This is important if a message arrived in a non-active conversation
+                self.load_and_display_recent_conversations()
+            else:
+                if self.has_unread_bot_messages:
+                    self.logger.info("Polling: All bot messages now read globally.")
+                    # Refresh list to remove any bolding if it was the last unread
+                    self.load_and_display_recent_conversations()
+                self.has_unread_bot_messages = False
+        except SQLAlchemyError as e:
+            self.logger.error(f"Database error during new message check: {e}", exc_info=True)
+        except Exception as e:
+            self.logger.error(f"Unexpected error during new message check: {e}", exc_info=True)
+
+    def trigger_notifications(self, count):
+        """Placeholder for actual notification logic."""
+        if not self.tray_icon.isVisible() and QSystemTrayIcon.isSystemTrayAvailable():
+            self.tray_icon.show() # Attempt to show it if it was hidden or system tray just became available
+
+        if self.tray_icon.isVisible(): # Only show message if tray icon is actually working
+            title = "New Botpress Message" if count == 1 else f"{count} New Botpress Messages"
+            message_body = f"You have {count} unread message(s) in the Botpress integration."
+            self.tray_icon.showMessage(title, message_body, QSystemTrayIcon.Information, 5000) # Show for 5 seconds
+            self.logger.info(f"Desktop notification shown for {count} messages.")
+
+            # Optional Sound Play
+            # if hasattr(self, 'notification_sound') and self.notification_sound.isLoaded():
+            #     self.notification_sound.play()
+            #     self.logger.info("Played notification sound.")
+        else:
+            self.logger.warning("Tried to trigger notification, but tray icon is not visible/available.")
+            # Fallback: Maybe a less intrusive in-app notification if tray is not available
+            # For example, update a status bar or add a message to the system messages area.
+            # self.add_message_to_display("system", f"You have {count} new unread non-user message(s).", datetime.now())
+
+
+    def handle_tray_icon_activated(self, reason):
+        if reason == QSystemTrayIcon.Trigger: # Typically a left click
+            self.logger.info("Tray icon activated by trigger (click). Attempting to show/activate window.")
+            parent_window = self.window()
+            if parent_window:
+                if parent_window.isMinimized():
+                    parent_window.showNormal()
+                parent_window.raise_()
+                parent_window.activateWindow()
+        elif reason == QSystemTrayIcon.Context: # Right click, could show a context menu
+            self.logger.info("Tray icon context menu requested (right-click). (Menu not implemented)")
+            # Here you could implement self.tray_icon.setContextMenu(your_menu)
+
 
     # --- Prompts Management ---
     def load_prompts(self):
@@ -413,7 +930,18 @@ class BotpressIntegrationUI(QWidget):
                 logging.error(f"Error deleting prompt_id {prompt_id}: {e}", exc_info=True)
 
     def closeEvent(self, event):
-        """Ensure database session is closed when the widget is closed."""
+        """Ensure resources are cleaned up when the widget is closed."""
+        if self.notification_timer:
+            self.notification_timer.stop()
+            self.logger.info("Notification timer stopped.")
+
+        if hasattr(self, 'tray_icon') and self.tray_icon.isVisible():
+            self.tray_icon.hide()
+            self.logger.info("System tray icon hidden.")
+            # For explicit cleanup if self is not its parent or to be very sure:
+            # del self.tray_icon
+            # self.tray_icon = None
+
         if self.db_session:
             self.db_session.close()
             logging.info("BotpressIntegrationUI: Database session closed.")

--- a/tests/botpress_integration/test_api_client.py
+++ b/tests/botpress_integration/test_api_client.py
@@ -1,0 +1,205 @@
+import unittest
+from unittest.mock import patch, MagicMock
+import requests # For requests.exceptions
+
+# Assuming your project structure allows this import:
+# Adjust if your project root is not directly discoverable by Python path
+# e.g. by setting PYTHONPATH environment variable or using sys.path.append
+from botpress_integration.api_client import BotpressClient, BotpressAPIError
+
+class TestBotpressClient(unittest.TestCase):
+
+    def test_init_default_base_url(self):
+        client = BotpressClient(api_key="test_key", bot_id="test_bot")
+        self.assertEqual(client.api_key, "test_key")
+        self.assertEqual(client.bot_id, "test_bot")
+        self.assertEqual(client.base_url, "https://api.botpress.cloud/v1/")
+        self.assertEqual(client.bot_specific_url, "https://api.botpress.cloud/v1/bots/test_bot")
+
+    def test_init_custom_base_url(self):
+        client = BotpressClient(api_key="test_key", bot_id="test_bot", base_url="http://localhost:3000/api/v1")
+        self.assertEqual(client.base_url, "http://localhost:3000/api/v1/") # Ensure trailing slash
+        self.assertEqual(client.bot_specific_url, "http://localhost:3000/api/v1/bots/test_bot")
+
+    def test_init_custom_base_url_without_trailing_slash(self):
+        client = BotpressClient(api_key="test_key", bot_id="test_bot", base_url="http://custom.domain/api/v1")
+        self.assertEqual(client.base_url, "http://custom.domain/api/v1/") # Ensure trailing slash is added
+        self.assertEqual(client.bot_specific_url, "http://custom.domain/api/v1/bots/test_bot")
+
+    @patch('botpress_integration.api_client.requests.post')
+    def test_send_message_success(self, mock_post):
+        mock_response = MagicMock()
+        mock_response.json.return_value = {"status": "success", "message_id": "msg123"}
+        mock_response.raise_for_status = MagicMock() # Does not raise for success
+        mock_post.return_value = mock_response
+
+        client = BotpressClient(api_key="test_key", bot_id="test_bot")
+        response = client.send_message("Hello Botpress", conversation_id="conv456")
+
+        expected_url = "https://api.botpress.cloud/v1/bots/test_bot/messages"
+        expected_payload = {
+            "text": "Hello Botpress",
+            "type": "text",
+            "conversationId": "conv456"
+        }
+        expected_headers = {
+            "Authorization": "Bearer test_key",
+            "Content-Type": "application/json"
+        }
+        mock_post.assert_called_once_with(
+            expected_url,
+            json=expected_payload,
+            headers=expected_headers,
+            timeout=10
+        )
+        self.assertEqual(response, {"status": "success", "message_id": "msg123"})
+
+    @patch('botpress_integration.api_client.requests.post')
+    def test_send_message_no_conversation_id(self, mock_post):
+        mock_response = MagicMock()
+        mock_response.json.return_value = {"status": "success_no_conv_id"}
+        mock_response.raise_for_status = MagicMock()
+        mock_post.return_value = mock_response
+
+        client = BotpressClient(api_key="test_key", bot_id="test_bot")
+        response = client.send_message("Hello direct to bot")
+
+        expected_payload = {
+            "text": "Hello direct to bot",
+            "type": "text"
+            # No conversationId
+        }
+        mock_post.assert_called_once_with(
+            unittest.mock.ANY, # URL
+            json=expected_payload,
+            headers=unittest.mock.ANY,
+            timeout=unittest.mock.ANY
+        )
+        self.assertEqual(response, {"status": "success_no_conv_id"})
+
+
+    @patch('botpress_integration.api_client.requests.post')
+    def test_send_message_http_error(self, mock_post):
+        mock_response = MagicMock()
+        # Simulate an HTTPError (e.g., 401 Unauthorized)
+        mock_response.raise_for_status.side_effect = requests.exceptions.HTTPError(
+            "401 Client Error: Unauthorized for url",
+            response=MagicMock(status_code=401, text="Auth error details")
+        )
+        mock_post.return_value = mock_response
+
+        client = BotpressClient(api_key="invalid_key", bot_id="test_bot")
+        with self.assertRaises(BotpressAPIError) as context:
+            client.send_message("test message")
+
+        self.assertTrue("401" in str(context.exception))
+        self.assertTrue("Auth error details" in str(context.exception))
+
+    @patch('botpress_integration.api_client.requests.post')
+    def test_send_message_connection_error(self, mock_post):
+        mock_post.side_effect = requests.exceptions.ConnectionError("Failed to connect")
+
+        client = BotpressClient(api_key="test_key", bot_id="test_bot")
+        with self.assertRaises(BotpressAPIError) as context:
+            client.send_message("test message")
+        self.assertTrue("Connection error" in str(context.exception))
+        self.assertTrue("Failed to connect" in str(context.exception))
+
+    @patch('botpress_integration.api_client.requests.post')
+    def test_send_message_timeout_error(self, mock_post):
+        mock_post.side_effect = requests.exceptions.Timeout("Request timed out")
+
+        client = BotpressClient(api_key="test_key", bot_id="test_bot")
+        with self.assertRaises(BotpressAPIError) as context:
+            client.send_message("test message")
+        self.assertTrue("Timeout sending message" in str(context.exception))
+        self.assertTrue("Request timed out" in str(context.exception))
+
+
+    @patch('botpress_integration.api_client.requests.get')
+    def test_get_conversations_success_no_conv_id(self, mock_get):
+        mock_response = MagicMock()
+        mock_response.json.return_value = {"messages": [{"id": "m1", "text": "hi"}]}
+        mock_response.raise_for_status = MagicMock()
+        mock_get.return_value = mock_response
+
+        client = BotpressClient(api_key="test_key", bot_id="test_bot")
+        response = client.get_conversations()
+
+        expected_url = "https://api.botpress.cloud/v1/bots/test_bot/messages"
+        mock_get.assert_called_once_with(
+            expected_url,
+            headers={"Authorization": "Bearer test_key"},
+            timeout=10
+        )
+        self.assertEqual(response, [{"id": "m1", "text": "hi"}])
+
+    @patch('botpress_integration.api_client.requests.get')
+    def test_get_conversations_success_with_conv_id(self, mock_get):
+        mock_response = MagicMock()
+        mock_response.json.return_value = {"messages": [{"id": "m2", "text": "hello"}]}
+        mock_response.raise_for_status = MagicMock()
+        mock_get.return_value = mock_response
+
+        client = BotpressClient(api_key="test_key", bot_id="test_bot")
+        response = client.get_conversations(conversation_id="conv123")
+
+        expected_url = "https://api.botpress.cloud/v1/bots/test_bot/conversations/conv123/messages"
+        mock_get.assert_called_once_with(
+            expected_url,
+            headers={"Authorization": "Bearer test_key"},
+            timeout=10
+        )
+        self.assertEqual(response, [{"id": "m2", "text": "hello"}])
+
+    @patch('botpress_integration.api_client.requests.get')
+    def test_get_conversations_http_error(self, mock_get):
+        mock_response = MagicMock()
+        mock_response.raise_for_status.side_effect = requests.exceptions.HTTPError(
+            "404 Client Error: Not Found for url",
+            response=MagicMock(status_code=404, text="Not found details")
+        )
+        mock_get.return_value = mock_response
+
+        client = BotpressClient(api_key="test_key", bot_id="test_bot")
+        with self.assertRaises(BotpressAPIError) as context:
+            client.get_conversations(conversation_id="non_existent_conv")
+        self.assertTrue("404" in str(context.exception))
+        self.assertTrue("Not found details" in str(context.exception))
+
+
+    @patch('botpress_integration.api_client.requests.get')
+    def test_get_bot_info_success(self, mock_get):
+        mock_response = MagicMock()
+        mock_response.json.return_value = {"name": "Test Bot", "version": "1.0"}
+        mock_response.raise_for_status = MagicMock()
+        mock_get.return_value = mock_response
+
+        client = BotpressClient(api_key="test_key", bot_id="test_bot_info")
+        response = client.get_bot_info()
+
+        expected_url = "https://api.botpress.cloud/v1/bots/test_bot_info"
+        mock_get.assert_called_once_with(
+            expected_url,
+            headers={"Authorization": "Bearer test_key"},
+            timeout=10
+        )
+        self.assertEqual(response, {"name": "Test Bot", "version": "1.0"})
+
+    @patch('botpress_integration.api_client.requests.get')
+    def test_get_bot_info_http_error(self, mock_get):
+        mock_response = MagicMock()
+        mock_response.raise_for_status.side_effect = requests.exceptions.HTTPError(
+            "500 Server Error", response=MagicMock(status_code=500, text="Server panic")
+        )
+        mock_get.return_value = mock_response
+
+        client = BotpressClient(api_key="test_key", bot_id="test_bot_info")
+        with self.assertRaises(BotpressAPIError) as context:
+            client.get_bot_info()
+        self.assertTrue("500" in str(context.exception))
+        self.assertTrue("Server panic" in str(context.exception))
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/botpress_integration/test_crud.py
+++ b/tests/botpress_integration/test_crud.py
@@ -1,0 +1,325 @@
+import unittest
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker, Session as SQLAlchemySession # Use alias to avoid confusion
+import logging
+
+# Adjust import path as necessary
+from botpress_integration.models import Base, UserBotpressSettings, UserPrompt, Conversation, Message, create_db_and_tables as main_create_db_and_tables
+from botpress_integration import crud
+# from botpress_integration.crud import has_unread_bot_messages # No longer needed to explicitly import if using crud.has_unread_bot_messages
+from datetime import datetime
+
+# Configure logging for tests (optional, but can be helpful)
+# logging.basicConfig(level=logging.DEBUG)
+
+class TestCrudOperations(unittest.TestCase):
+
+    engine = None
+    SessionLocalTest = None
+
+    @classmethod
+    def setUpClass(cls):
+        cls.engine = create_engine("sqlite:///:memory:")
+        # We need to pass the engine to the models.Base.metadata.create_all
+        # If create_db_and_tables from models.py uses a global engine, we need to adapt.
+        # For now, let's assume create_db_and_tables can accept an engine or we call Base.metadata.create_all directly.
+        Base.metadata.create_all(bind=cls.engine)
+        cls.SessionLocalTest = sessionmaker(autocommit=False, autoflush=False, bind=cls.engine)
+        logging.info("In-memory SQLite DB initialized for testing CRUD operations.")
+
+    def setUp(self):
+        # Create a new session for each test
+        self.db: SQLAlchemySession = self.SessionLocalTest()
+        # Clear data from tables before each test to ensure isolation
+        self._clear_all_tables()
+
+    def _clear_all_tables(self):
+        # Delete data in reverse order of creation due to foreign key constraints
+        self.db.query(Message).delete()
+        self.db.query(Conversation).delete()
+        self.db.query(UserPrompt).delete()
+        self.db.query(UserBotpressSettings).delete()
+        self.db.commit()
+
+    def tearDown(self):
+        self.db.close()
+
+    # --- UserBotpressSettings Tests ---
+    def test_create_and_get_botpress_settings(self):
+        created_settings = crud.create_or_update_botpress_settings(
+            self.db, "user1", "key1", "bot1", "en", "http://localhost:3000"
+        )
+        self.assertIsNotNone(created_settings.id)
+        self.assertEqual(created_settings.user_id, "user1")
+        self.assertEqual(created_settings.api_key, "key1")
+        self.assertEqual(created_settings.bot_id, "bot1")
+        self.assertEqual(created_settings.preferred_language, "en")
+        self.assertEqual(created_settings.base_url, "http://localhost:3000")
+
+        retrieved_settings = crud.get_botpress_settings(self.db, "user1")
+        self.assertIsNotNone(retrieved_settings)
+        self.assertEqual(retrieved_settings.id, created_settings.id)
+        self.assertEqual(retrieved_settings.base_url, "http://localhost:3000")
+
+    def test_get_botpress_settings_not_found(self):
+        retrieved_settings = crud.get_botpress_settings(self.db, "non_existent_user")
+        self.assertIsNone(retrieved_settings)
+
+    def test_update_botpress_settings(self):
+        crud.create_or_update_botpress_settings(
+            self.db, "user2", "key2_orig", "bot2_orig", "en", None
+        )
+        updated_settings = crud.create_or_update_botpress_settings(
+            self.db, "user2", "key2_new", "bot2_new", "fr", "https://new.url"
+        )
+        self.assertEqual(updated_settings.api_key, "key2_new")
+        self.assertEqual(updated_settings.bot_id, "bot2_new")
+        self.assertEqual(updated_settings.preferred_language, "fr")
+        self.assertEqual(updated_settings.base_url, "https://new.url")
+
+        # Test updating to remove base_url
+        updated_settings_no_base = crud.create_or_update_botpress_settings(
+            self.db, "user2", "key2_final", "bot2_final", "de", None
+        )
+        self.assertEqual(updated_settings_no_base.base_url, None)
+
+
+    def test_delete_botpress_settings(self):
+        settings = crud.create_or_update_botpress_settings(
+            self.db, "user_to_delete", "key_del", "bot_del"
+        )
+        # Add a prompt to ensure cascade delete is handled (or verify it's deleted)
+        crud.create_user_prompt(self.db, settings.id, "test_prompt", "text")
+
+        delete_result = crud.delete_botpress_settings(self.db, "user_to_delete")
+        self.assertTrue(delete_result)
+        self.assertIsNone(crud.get_botpress_settings(self.db, "user_to_delete"))
+        # Verify prompts are also deleted
+        prompts = crud.get_prompts_for_user(self.db, settings.id)
+        self.assertEqual(len(prompts), 0)
+
+
+    def test_delete_botpress_settings_not_found(self):
+        delete_result = crud.delete_botpress_settings(self.db, "non_existent_user_for_delete")
+        self.assertFalse(delete_result)
+
+    # --- UserPrompt Tests ---
+    def test_create_and_get_user_prompt(self):
+        settings = crud.create_or_update_botpress_settings(self.db, "user_prompt_test", "k", "b")
+
+        prompt = crud.create_user_prompt(self.db, settings.id, "Greeting", "Hello there!")
+        self.assertIsNotNone(prompt.id)
+        self.assertEqual(prompt.prompt_name, "Greeting")
+        self.assertEqual(prompt.prompt_text, "Hello there!")
+        self.assertEqual(prompt.settings_id, settings.id)
+
+        retrieved_prompt = crud.get_prompt_by_name(self.db, settings.id, "Greeting")
+        self.assertIsNotNone(retrieved_prompt)
+        self.assertEqual(retrieved_prompt.id, prompt.id)
+
+    def test_create_duplicate_user_prompt_name(self):
+        settings = crud.create_or_update_botpress_settings(self.db, "user_dup_prompt", "k", "b")
+        crud.create_user_prompt(self.db, settings.id, "UniquePrompt", "Text1")
+        with self.assertRaises(ValueError):
+            crud.create_user_prompt(self.db, settings.id, "UniquePrompt", "Text2")
+
+    def test_get_prompts_for_user(self):
+        settings = crud.create_or_update_botpress_settings(self.db, "user_multi_prompt", "k", "b")
+        crud.create_user_prompt(self.db, settings.id, "Prompt1", "1")
+        crud.create_user_prompt(self.db, settings.id, "Prompt2", "2")
+
+        prompts = crud.get_prompts_for_user(self.db, settings.id)
+        self.assertEqual(len(prompts), 2)
+
+    def test_update_user_prompt(self):
+        settings = crud.create_or_update_botpress_settings(self.db, "user_update_prompt", "k", "b")
+        prompt = crud.create_user_prompt(self.db, settings.id, "OldName", "OldText")
+
+        updated_prompt = crud.update_user_prompt(self.db, prompt.id, "NewName", "NewText")
+        self.assertEqual(updated_prompt.prompt_name, "NewName")
+        self.assertEqual(updated_prompt.prompt_text, "NewText")
+
+        # Test updating only one field
+        updated_prompt_text_only = crud.update_user_prompt(self.db, prompt.id, prompt_text="OnlyTextUpdated")
+        self.assertEqual(updated_prompt_text_only.prompt_name, "NewName") # Should retain previous name
+        self.assertEqual(updated_prompt_text_only.prompt_text, "OnlyTextUpdated")
+
+    def test_update_user_prompt_name_conflict(self):
+        settings = crud.create_or_update_botpress_settings(self.db, "user_prompt_name_conflict", "k","b")
+        prompt1 = crud.create_user_prompt(self.db, settings.id, "Name1", "Text1")
+        prompt2 = crud.create_user_prompt(self.db, settings.id, "Name2", "Text2")
+        with self.assertRaises(ValueError):
+            crud.update_user_prompt(self.db, prompt2.id, prompt_name="Name1") # Trying to rename prompt2 to Name1
+
+    def test_delete_user_prompt(self):
+        settings = crud.create_or_update_botpress_settings(self.db, "user_del_prompt", "k", "b")
+        prompt = crud.create_user_prompt(self.db, settings.id, "ToDelete", "...")
+
+        result = crud.delete_user_prompt(self.db, prompt.id)
+        self.assertTrue(result)
+        self.assertIsNone(crud.get_prompt_by_name(self.db, settings.id, "ToDelete"))
+
+    # --- Conversation and Message Tests to be added here ---
+    def test_create_get_or_create_conversation(self):
+        bp_conv_id = "bp_test_conv_001"
+        conv1 = crud.create_conversation(self.db, bp_conv_id, "web", "user_xyz", "active")
+        self.assertEqual(conv1.botpress_conversation_id, bp_conv_id)
+        self.assertEqual(conv1.channel_type, "web")
+
+        conv2 = crud.get_conversation_by_botpress_id(self.db, bp_conv_id)
+        self.assertEqual(conv1.id, conv2.id)
+
+        conv3 = crud.get_or_create_conversation(self.db, bp_conv_id, "sms", "user_abc") # Should get existing
+        self.assertEqual(conv1.id, conv3.id)
+        # Current get_or_create doesn't update existing, so channel_type remains 'web'
+        self.assertEqual(conv3.channel_type, "web")
+
+
+        bp_conv_id_new = "bp_test_conv_002"
+        conv4 = crud.get_or_create_conversation(self.db, bp_conv_id_new, "messenger") # Should create new
+        self.assertEqual(conv4.botpress_conversation_id, bp_conv_id_new)
+        self.assertEqual(conv4.channel_type, "messenger")
+
+    def test_update_conversation_status_and_timestamp(self):
+        conv = crud.create_conversation(self.db, "bp_conv_status_ts", "web")
+        original_ts = conv.last_message_timestamp
+
+        updated_conv_status = crud.update_conversation_status(self.db, conv.id, "archived")
+        self.assertEqual(updated_conv_status.status, "archived")
+
+        new_ts = datetime.utcnow()
+        updated_conv_ts = crud.update_conversation_timestamp(self.db, conv.id, new_ts)
+        self.assertEqual(updated_conv_ts.last_message_timestamp, new_ts)
+        self.assertNotEqual(original_ts, new_ts)
+
+    def test_get_recent_conversations(self):
+        crud.create_conversation(self.db, "conv_old", "web", last_message_timestamp=datetime(2023, 1, 1, 10, 0, 0))
+        conv_new = crud.create_conversation(self.db, "conv_new", "web", last_message_timestamp=datetime(2023, 1, 1, 12, 0, 0))
+
+        recent = crud.get_recent_conversations(self.db, limit=1)
+        self.assertEqual(len(recent), 1)
+        self.assertEqual(recent[0].id, conv_new.id)
+
+    def test_add_and_get_messages(self):
+        conv = crud.create_conversation(self.db, "conv_for_msgs", "chat")
+        ts_before_msg = conv.last_message_timestamp
+
+        msg_content1 = "Hello from user"
+        msg_ts1 = datetime.utcnow()
+        msg1 = crud.add_message(self.db, conv.id, "user", msg_content1, msg_ts1, "bp_msg_1")
+        self.assertEqual(msg1.content, msg_content1)
+        self.assertEqual(msg1.sender_type, "user")
+        self.assertEqual(msg1.botpress_message_id, "bp_msg_1")
+        self.assertTrue(msg1.is_read, "User message should be read by default")
+
+        # Check conversation's last_message_timestamp was updated
+        conv_reloaded = crud.get_conversation_by_botpress_id(self.db, "conv_for_msgs")
+        self.assertEqual(conv_reloaded.last_message_timestamp, msg_ts1)
+
+        msg_content2 = "Reply from bot"
+        msg_ts2 = datetime.utcnow()
+        suggestions_json = '[{"title": "Option 1", "payload": "opt1"}]'
+        msg2 = crud.add_message(self.db, conv.id, "bot", msg_content2, msg_ts2, "bp_msg_2", suggestions_json)
+        self.assertEqual(msg2.suggestions, suggestions_json)
+        self.assertFalse(msg2.is_read, "Bot message should be unread by default")
+
+        conv_reloaded_again = crud.get_conversation_by_botpress_id(self.db, "conv_for_msgs")
+        self.assertEqual(conv_reloaded_again.last_message_timestamp, msg_ts2)
+
+        # Test explicit is_read
+        msg_user_unread = crud.add_message(self.db, conv.id, "user", "Test unread user", datetime.utcnow(), is_read=False)
+        self.assertFalse(msg_user_unread.is_read, "User message explicitly set to unread")
+
+        msg_bot_read = crud.add_message(self.db, conv.id, "bot", "Test read bot", datetime.utcnow(), is_read=True)
+        self.assertTrue(msg_bot_read.is_read, "Bot message explicitly set to read")
+
+        messages_for_conv = crud.get_messages_for_conversation(self.db, conv.id, limit=10)
+        self.assertEqual(len(messages_for_conv), 4) # 2 default + 2 explicit
+        self.assertEqual(messages_for_conv[0].id, msg1.id)
+        self.assertEqual(messages_for_conv[1].id, msg2.id)
+
+        retrieved_msg_by_bp_id = crud.get_message_by_botpress_id(self.db, "bp_msg_1")
+        self.assertEqual(retrieved_msg_by_bp_id.id, msg1.id)
+
+    def test_mark_messages_as_read(self):
+        conv = crud.create_conversation(self.db, "conv_mark_read", "test")
+        # Add messages
+        crud.add_message(self.db, conv.id, "user", "User msg 1", datetime.utcnow(), is_read=True) # Already read
+        crud.add_message(self.db, conv.id, "bot", "Bot msg 1 (unread)", datetime.utcnow(), is_read=False)
+        crud.add_message(self.db, conv.id, "agent", "Agent msg (unread)", datetime.utcnow(), is_read=False)
+        crud.add_message(self.db, conv.id, "bot", "Bot msg 2 (read)", datetime.utcnow(), is_read=True)
+
+        # Mark messages as read
+        updated_count = crud.mark_messages_as_read(self.db, conv.id)
+        self.assertEqual(updated_count, 2, "Should have updated 2 messages (bot msg 1, agent msg)")
+
+        # Verify all messages are now read
+        messages = crud.get_messages_for_conversation(self.db, conv.id)
+        for msg in messages:
+            self.assertTrue(msg.is_read, f"Message {msg.id} should be read")
+
+        # Test with a conversation with no unread messages
+        updated_count_none = crud.mark_messages_as_read(self.db, conv.id)
+        self.assertEqual(updated_count_none, 0)
+
+        # Test with a non-existent conversation ID
+        updated_count_non_existent = crud.mark_messages_as_read(self.db, 99999)
+        self.assertEqual(updated_count_non_existent, 0)
+
+    def test_count_unread_bot_messages(self):
+        # Scenario 1: No unread messages
+        self.assertEqual(crud.count_unread_bot_messages(self.db), 0)
+
+        # Scenario 2: Add conversations and messages
+        conv1 = crud.create_conversation(self.db, "c1_unread_test")
+        crud.add_message(self.db, conv1.id, "user", "u1", datetime.utcnow()) # Read
+        crud.add_message(self.db, conv1.id, "bot", "b1 unread", datetime.utcnow()) # Unread
+        crud.add_message(self.db, conv1.id, "agent", "a1 unread", datetime.utcnow()) # Unread
+
+        conv2 = crud.create_conversation(self.db, "c2_unread_test")
+        crud.add_message(self.db, conv2.id, "bot", "b2 unread", datetime.utcnow()) # Unread
+        crud.add_message(self.db, conv2.id, "system", "s2 read", datetime.utcnow(), is_read=True) # Read
+
+        # Assert count is 3 (b1, a1, b2)
+        self.assertEqual(crud.count_unread_bot_messages(self.db), 3)
+
+        # Mark some as read
+        crud.mark_messages_as_read(self.db, conv1.id) # Marks b1, a1 as read
+        self.assertEqual(crud.count_unread_bot_messages(self.db), 1) # Only b2 left
+
+        crud.mark_messages_as_read(self.db, conv2.id) # Marks b2 as read
+        self.assertEqual(crud.count_unread_bot_messages(self.db), 0)
+
+    def test_has_unread_bot_messages(self):
+        conv_test = crud.create_conversation(self.db, "conv_has_unread")
+
+        # Test with no messages
+        self.assertFalse(crud.has_unread_bot_messages(self.db, conv_test.id))
+
+        # Test with only read bot messages
+        crud.add_message(self.db, conv_test.id, "bot", "read bot", datetime.utcnow(), is_read=True)
+        self.assertFalse(crud.has_unread_bot_messages(self.db, conv_test.id))
+
+        # Test with only unread user messages
+        crud.add_message(self.db, conv_test.id, "user", "unread user", datetime.utcnow(), is_read=False) # User messages are read by default if is_read=None
+        # Re-add user message explicitly as unread to test the filter for "sender_type != 'user'"
+        user_msg = self.db.query(Message).filter(Message.conversation_id == conv_test.id, Message.sender_type == 'user').first()
+        if user_msg: # If it was created by add_message (which auto-sets user to read)
+            user_msg.is_read = False
+            self.db.commit()
+        else: # If not, then add one as unread
+             crud.add_message(self.db, conv_test.id, "user", "explicit unread user", datetime.utcnow(), is_read=False)
+
+        self.assertFalse(crud.has_unread_bot_messages(self.db, conv_test.id), "Should be false as only user message is unread")
+
+        # Test with unread bot messages
+        crud.add_message(self.db, conv_test.id, "bot", "unread bot 2", datetime.utcnow(), is_read=False)
+        self.assertTrue(crud.has_unread_bot_messages(self.db, conv_test.id))
+
+        # Test after marking messages as read
+        crud.mark_messages_as_read(self.db, conv_test.id)
+        self.assertFalse(crud.has_unread_bot_messages(self.db, conv_test.id))
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/botpress_integration/test_ui_components.py
+++ b/tests/botpress_integration/test_ui_components.py
@@ -1,0 +1,358 @@
+import unittest
+from unittest.mock import patch, MagicMock, ANY
+import sys
+
+from PyQt5.QtWidgets import QApplication, QWidget
+from PyQt5.QtCore import Qt
+
+# Ensure a QApplication instance exists for widget testing
+app = QApplication.instance()
+if app is None:
+    app = QApplication(sys.argv)
+
+# Adjust import paths as necessary
+from botpress_integration import crud # To mock its functions
+from botpress_integration.ui_components import BotpressIntegrationUI, CONVO_ID_ROLE, BP_CONVO_ID_ROLE, IS_UNREAD_ROLE
+from botpress_integration.api_client import BotpressClient
+from botpress_integration.models import UserBotpressSettings, Conversation, Message
+from PyQt5.QtWidgets import QListWidgetItem, QSystemTrayIcon
+from PyQt5.QtGui import QFont
+
+
+class TestBotpressIntegrationUI(unittest.TestCase):
+
+    @patch('botpress_integration.ui_components.SessionLocal')
+    @patch('botpress_integration.ui_components.create_db_and_tables')
+    @patch('PyQt5.QtWidgets.QSystemTrayIcon.isSystemTrayAvailable', return_value=True) # Assume tray is available
+    def setUp(self, mock_tray_available, mock_create_db, mock_session_local):
+        self.mock_db_session = MagicMock()
+        mock_session_local.return_value = self.mock_db_session
+
+        self.parent_widget = QWidget()
+        # Patch the tray icon directly in the UI's __init__ if it's created there
+        # For simplicity, we might let it be created and then mock its methods if needed,
+        # or patch QSystemTrayIcon globally if that's easier.
+        # Let's assume self.ui.tray_icon will be a MagicMock for some tests.
+        self.ui = BotpressIntegrationUI(parent=self.parent_widget, current_user_id="test_user")
+        # Mock the tray_icon's methods if it was created by the UI, to avoid actual notifications
+        if hasattr(self.ui, 'tray_icon'):
+            self.ui.tray_icon = MagicMock(spec=QSystemTrayIcon)
+            self.ui.tray_icon.isVisible.return_value = True # Assume it's visible for tests that need it
+
+
+    def tearDown(self):
+        if self.parent_widget:
+            self.parent_widget.deleteLater() # Ensure proper Qt cleanup
+        del self.ui
+
+    @patch('botpress_integration.ui_components.crud.get_botpress_settings')
+    @patch('botpress_integration.ui_components.crud.get_or_create_conversation')
+    @patch('botpress_integration.ui_components.BotpressClient')
+    @patch.object(BotpressIntegrationUI, 'load_and_display_recent_conversations') # Mock this to prevent its full execution
+    @patch('PyQt5.QtWidgets.QMessageBox')
+    def test_load_settings_existing_settings(self, mock_qmessagebox, mock_load_recent_convos_ui, mock_botpress_client, mock_get_or_create_conv, mock_get_settings):
+        mock_settings = UserBotpressSettings(id=1, user_id="test_user", api_key="key", bot_id="bot", base_url="url")
+        mock_get_settings.return_value = mock_settings
+        mock_conv = Conversation(id=1, botpress_conversation_id="bot_main_chat")
+        mock_get_or_create_conv.return_value = mock_conv
+        mock_api_client_instance = MagicMock(spec=BotpressClient)
+        mock_botpress_client.return_value = mock_api_client_instance
+
+        with patch.object(self.ui.notification_timer, 'start') as mock_timer_start, \
+             patch.object(self.ui, 'check_for_new_messages') as mock_check_new_msg:
+            self.ui.load_settings()
+
+        mock_get_settings.assert_called_once_with(self.mock_db_session, user_id="test_user")
+        self.assertEqual(self.ui.api_key_input.text(), "key")
+        self.assertEqual(self.ui.bot_id_input.text(), "bot")
+        self.assertEqual(self.ui.base_url_input.text(), "url")
+        mock_botpress_client.assert_called_once_with(api_key="key", bot_id="bot", base_url="url")
+        mock_get_or_create_conv.assert_called_once()
+        self.assertEqual(self.ui.current_db_conversation_id, 1)
+        mock_load_recent_convos_ui.assert_called_once()
+        mock_timer_start.assert_called_once_with(15000)
+        mock_check_new_msg.assert_called_once()
+
+
+    @patch('botpress_integration.ui_components.crud.get_botpress_settings')
+    @patch('PyQt5.QtWidgets.QMessageBox')
+    def test_load_settings_no_existing_settings(self, mock_qmessagebox, mock_get_settings):
+        mock_get_settings.return_value = None
+        with patch.object(self.ui.notification_timer, 'stop') as mock_timer_stop:
+            self.ui.load_settings()
+
+        mock_get_settings.assert_called_once_with(self.mock_db_session, user_id="test_user")
+        self.assertEqual(self.ui.api_key_input.text(), "")
+        self.assertEqual(self.ui.base_url_input.text(), "https://api.botpress.cloud/v1/")
+        self.assertIsNone(self.ui.botpress_client)
+        mock_timer_stop.assert_called_once()
+
+
+    @patch('botpress_integration.ui_components.crud.create_or_update_botpress_settings')
+    @patch('botpress_integration.ui_components.BotpressClient')
+    @patch.object(BotpressIntegrationUI, 'load_and_display_recent_conversations')
+    @patch('PyQt5.QtWidgets.QMessageBox')
+    def test_save_settings_new_settings(self, mock_qmessagebox, mock_load_recent_convos, mock_botpress_client, mock_create_update_settings):
+        self.ui.api_key_input.setText("new_key")
+        self.ui.bot_id_input.setText("new_bot")
+        self.ui.base_url_input.setText("http://new.url/")
+        mock_saved_settings = UserBotpressSettings(id=2, user_id="test_user", api_key="new_key", bot_id="new_bot", base_url="http://new.url/")
+        mock_create_update_settings.return_value = mock_saved_settings
+        mock_api_client_instance = MagicMock(spec=BotpressClient)
+        mock_botpress_client.return_value = mock_api_client_instance
+
+        with patch.object(self.ui.notification_timer, 'start') as mock_timer_start, \
+             patch.object(self.ui, 'check_for_new_messages') as mock_check_new_msg:
+            self.ui.save_settings()
+
+        mock_create_update_settings.assert_called_once_with(
+            self.mock_db_session, user_id="test_user", api_key="new_key", bot_id="new_bot", base_url="http://new.url/"
+        )
+        mock_botpress_client.assert_called_once_with(api_key="new_key", bot_id="new_bot", base_url="http://new.url/")
+        mock_load_recent_convos.assert_called_once()
+        mock_timer_start.assert_called_once_with(15000)
+        mock_check_new_msg.assert_called_once()
+
+
+    @patch('botpress_integration.ui_components.crud.create_or_update_botpress_settings')
+    @patch('botpress_integration.ui_components.BotpressClient')
+    @patch('PyQt5.QtWidgets.QMessageBox')
+    def test_save_settings_empty_base_url_saves_none(self, mock_qmessagebox, mock_botpress_client, mock_create_update_settings):
+        self.ui.api_key_input.setText("key_no_base")
+        self.ui.bot_id_input.setText("bot_no_base")
+        self.ui.base_url_input.setText("") # Empty base URL
+
+        mock_saved_settings = UserBotpressSettings(id=3, user_id="test_user", api_key="key_no_base", bot_id="bot_no_base", base_url=None)
+        mock_create_update_settings.return_value = mock_saved_settings
+
+        self.ui.save_settings()
+
+        mock_create_update_settings.assert_called_once_with(
+            self.mock_db_session,
+            user_id="test_user",
+            api_key="key_no_base",
+            bot_id="bot_no_base",
+            base_url=None # Should save None
+        )
+        mock_botpress_client.assert_called_once_with(api_key="key_no_base", bot_id="bot_no_base", base_url="https://api.botpress.cloud/v1/") # Client uses default
+
+
+    @patch('botpress_integration.ui_components.crud.add_message')
+    @patch.object(BotpressIntegrationUI, 'add_message_to_display') # Mocking the instance method
+    @patch.object(BotpressIntegrationUI, 'load_and_display_recent_conversations')
+    @patch.object(BotpressIntegrationUI, 'restore_conversation_list_selection')
+    @patch('PyQt5.QtWidgets.QMessageBox')
+    def test_handle_send_message_success(self, mock_qmessagebox, mock_restore_selection, mock_load_recent_convos, mock_add_msg_display, mock_crud_add_msg):
+        # Arrange
+        self.ui.botpress_client = MagicMock(spec=BotpressClient)
+        # Simulate a successful API response with suggestions
+        mock_api_response = {
+            "message": { # Assuming this structure based on previous work
+                "id": "bp_msg_123",
+                "conversationId": "bp_conv_abc",
+                "text": "Hello from bot!",
+                "suggestions": [{"title": "OK", "payload": "ok_payload"}]
+            }
+        }
+        self.ui.botpress_client.send_message.return_value = mock_api_response
+
+        self.ui.current_db_conversation_id = 1 # Assume a conversation is active
+        self.ui.current_botpress_conversation_id = "bp_conv_abc" # Initial Botpress conv ID
+        self.ui.message_input.setText("Hello there")
+
+        # Act
+        self.ui.handle_send_message()
+
+        # Assert
+        # 1. User message displayed and saved
+        mock_add_msg_display.assert_any_call(sender_type='user', text="Hello there", timestamp=ANY)
+        mock_crud_add_msg.assert_any_call(self.mock_db_session, conversation_id=1, sender_type='user', content="Hello there", timestamp=ANY)
+
+        # 2. API client called
+        self.ui.botpress_client.send_message.assert_called_once_with("Hello there", conversation_id="bp_conv_abc")
+
+        # 3. Bot message displayed and saved (with suggestions)
+        mock_add_msg_display.assert_any_call(sender_type='bot', text="Hello from bot!", timestamp=ANY, suggestions=[{"title": "OK", "payload": "ok_payload"}])
+        mock_crud_add_msg.assert_any_call(
+            self.mock_db_session,
+            conversation_id=1,
+            sender_type='bot',
+            content="Hello from bot!",
+            timestamp=ANY,
+            botpress_message_id="bp_msg_123",
+            suggestions='[{"title": "OK", "payload": "ok_payload"}]' # JSON string
+        )
+
+        self.assertEqual(self.ui.message_input.text(), "") # Input cleared
+        mock_load_recent_convos.assert_called_once()
+        mock_restore_selection.assert_called_once_with(1)
+
+
+    @patch.object(BotpressIntegrationUI, 'handle_send_message') # Mock the method that would be called
+    @patch('PyQt5.QtWidgets.QMessageBox')
+    def test_handle_suggestion_clicked(self, mock_qmessagebox, mock_handle_send):
+        test_payload = "suggestion_payload_text"
+        mock_message_widget_container = QWidget()
+        self.ui.handle_suggestion_clicked(test_payload, mock_message_widget_container)
+        self.assertEqual(self.ui.message_input.text(), test_payload)
+        mock_handle_send.assert_called_once()
+
+    # --- Notification and Unread Indicator Tests ---
+
+    @patch('botpress_integration.ui_components.crud.count_unread_bot_messages')
+    @patch.object(BotpressIntegrationUI, 'trigger_notifications')
+    @patch.object(BotpressIntegrationUI, 'load_and_display_recent_conversations')
+    def test_check_for_new_messages_polling(self, mock_load_convos, mock_trigger_notif, mock_count_unread):
+        self.ui.botpress_client = MagicMock() # Ensure client is considered "ready"
+
+        # Scenario 1: No unread messages
+        mock_count_unread.return_value = 0
+        self.ui.has_unread_bot_messages = False # Initial state
+        self.ui.check_for_new_messages()
+        mock_trigger_notif.assert_not_called()
+        self.assertFalse(self.ui.has_unread_bot_messages)
+        # load_and_display_recent_conversations might be called if state changed, ensure it is if needed
+        # For now, let's assume it's called if has_unread_bot_messages changes from True to False.
+
+        # Scenario 2: New unread messages appear
+        mock_count_unread.return_value = 3
+        self.ui.has_unread_bot_messages = False # State before finding new messages
+        self.ui.check_for_new_messages()
+        mock_trigger_notif.assert_called_once_with(3)
+        self.assertTrue(self.ui.has_unread_bot_messages)
+        mock_load_convos.assert_called_once() # Should refresh list to show bolding
+
+        mock_trigger_notif.reset_mock()
+        mock_load_convos.reset_mock()
+
+        # Scenario 3: Unread messages persist, no new notification
+        self.ui.has_unread_bot_messages = True # State remains true
+        self.ui.check_for_new_messages() # count still 3
+        mock_trigger_notif.assert_not_called() # Should not notify again for the same state
+        self.assertTrue(self.ui.has_unread_bot_messages)
+        # Depending on design, load_and_display_recent_conversations might or might not be called here.
+        # If it's only for state *change*, it shouldn't. If it's for any unread count > 0, it should.
+        # Current logic in check_for_new_messages implies it's called if unread_count > 0.
+        mock_load_convos.assert_called_once()
+
+        mock_load_convos.reset_mock()
+        # Scenario 4: Messages become read
+        mock_count_unread.return_value = 0
+        self.ui.has_unread_bot_messages = True # State was true
+        self.ui.check_for_new_messages()
+        self.assertFalse(self.ui.has_unread_bot_messages)
+        mock_load_convos.assert_called_once() # Should refresh to remove bolding
+
+    def test_trigger_notifications(self):
+        # self.ui.tray_icon is already a MagicMock from setUp
+        self.ui.trigger_notifications(3)
+        self.ui.tray_icon.showMessage.assert_called_with(
+            "3 New Botpress Messages",
+            "You have 3 unread message(s) in the Botpress integration.",
+            QSystemTrayIcon.Information,
+            5000
+        )
+        self.ui.trigger_notifications(1)
+        self.ui.tray_icon.showMessage.assert_called_with(
+            "New Botpress Message",
+            "You have 1 unread message(s) in the Botpress integration.",
+            QSystemTrayIcon.Information,
+            5000
+        )
+
+    def test_update_conversation_item_style(self):
+        mock_item = MagicMock(spec=QListWidgetItem)
+        mock_font = MagicMock(spec=QFont)
+        mock_item.font.return_value = mock_font
+
+        # Test setting as unread
+        self.ui.update_conversation_item_style(mock_item, True, base_text="Test Convo")
+        mock_font.setBold.assert_called_with(True)
+        mock_item.setText.assert_called_with("[UNREAD] Test Convo")
+        mock_item.setData.assert_called_with(IS_UNREAD_ROLE, True)
+
+        # Test setting as read (when it was unread)
+        mock_item.text.return_value = "[UNREAD] Test Convo" # Simulate current text
+        self.ui.update_conversation_item_style(mock_item, False, base_text="Test Convo") # Pass base_text for proper stripping
+        mock_font.setBold.assert_called_with(False)
+        mock_item.setText.assert_called_with("Test Convo")
+        mock_item.setData.assert_called_with(IS_UNREAD_ROLE, False)
+
+        # Test setting as read (when it was already read, no marker)
+        mock_item.text.return_value = "Test Convo"
+        self.ui.update_conversation_item_style(mock_item, False, base_text="Test Convo")
+        mock_font.setBold.assert_called_with(False)
+        mock_item.setText.assert_called_with("Test Convo") # Should remain the same
+        mock_item.setData.assert_called_with(IS_UNREAD_ROLE, False)
+
+
+    @patch('botpress_integration.ui_components.crud.get_recent_conversations')
+    @patch('botpress_integration.ui_components.crud.has_unread_bot_messages')
+    @patch.object(BotpressIntegrationUI, 'update_conversation_item_style')
+    def test_load_and_display_recent_conversations_unread_styling(self, mock_update_style, mock_has_unread, mock_get_recent):
+        mock_convo1 = Conversation(id=1, botpress_conversation_id="bp1", last_message_timestamp=datetime.now())
+        mock_convo2 = Conversation(id=2, botpress_conversation_id="bp2", last_message_timestamp=datetime.now())
+        mock_get_recent.return_value = [mock_convo1, mock_convo2]
+
+        # Simulate one convo unread, one read
+        mock_has_unread.side_effect = lambda db, convo_id: True if convo_id == mock_convo1.id else False
+
+        self.ui.load_and_display_recent_conversations()
+
+        self.assertEqual(mock_update_style.call_count, 2)
+        # Check calls to update_conversation_item_style
+        # First call for mock_convo1 (should be unread=True)
+        args_convo1, _ = mock_update_style.call_args_list[0]
+        self.assertIsInstance(args_convo1[0], QListWidgetItem) # item
+        self.assertTrue(args_convo1[1]) # is_unread = True
+        self.assertTrue("bp1" in args_convo1[2]) # base_text contains convo id
+
+        # Second call for mock_convo2 (should be unread=False)
+        args_convo2, _ = mock_update_style.call_args_list[1]
+        self.assertIsInstance(args_convo2[0], QListWidgetItem) # item
+        self.assertFalse(args_convo2[1]) # is_unread = False
+        self.assertTrue("bp2" in args_convo2[2]) # base_text
+
+    @patch('botpress_integration.ui_components.crud.mark_messages_as_read')
+    @patch.object(BotpressIntegrationUI, 'update_conversation_item_style')
+    @patch.object(BotpressIntegrationUI, 'check_for_new_messages')
+    @patch.object(BotpressIntegrationUI, 'load_conversation_history') # Mock this to simplify test
+    def test_handle_conversation_selected_marks_read_and_updates_style(self, mock_load_history, mock_check_new, mock_update_style, mock_mark_read):
+        mock_mark_read.return_value = 1 # Simulate 1 message was marked as read
+
+        mock_item = QListWidgetItem()
+        mock_item.setData(CONVO_ID_ROLE, 123)
+        mock_item.setData(BP_CONVO_ID_ROLE, "bp_conv_selected")
+        mock_item.setData(IS_UNREAD_ROLE, True) # Initially unread
+
+        self.ui.handle_conversation_selected(mock_item, None)
+
+        mock_mark_read.assert_called_once_with(self.mock_db_session, conversation_id=123)
+        mock_update_style.assert_called_once_with(mock_item, False)
+        mock_check_new.assert_called_once()
+        mock_load_history.assert_called_once() # Ensure history is loaded for selected item
+
+    @patch.object(QWidget, 'showNormal') # Mocking QWidget's method
+    @patch.object(QWidget, 'raise_')
+    @patch.object(QWidget, 'activateWindow')
+    def test_handle_tray_icon_activated(self, mock_activate, mock_raise, mock_show_normal):
+        # To properly test this, self.ui.window() needs to return a mockable window.
+        # If self.ui is the top-level window, self.ui.window() is self.ui.
+        # We can patch self.ui directly for these methods.
+
+        with patch.object(self.ui, 'window', return_value=self.ui) as mock_get_window: # mock self.window() call
+            with patch.object(self.ui, 'isMinimized', return_value=True): # Simulate minimized
+                 with patch.object(self.ui, 'showNormal') as self_show_normal, \
+                      patch.object(self.ui, 'raise_') as self_raise, \
+                      patch.object(self.ui, 'activateWindow') as self_activate:
+
+                    self.ui.handle_tray_icon_activated(QSystemTrayIcon.Trigger)
+
+                    mock_get_window.assert_called()
+                    self_show_normal.assert_called_once()
+                    self_raise.assert_called_once()
+                    self_activate.assert_called_once()
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
This commit introduces features for notifying you of new messages and visually indicating unread conversations in the Botpress integration module.

Key changes include:

1.  **Message Read Status**:
    *   Added an `is_read` boolean field to the `Message` model.
    *   Updated `add_message` CRUD to set `is_read` (True for your own messages, False for new bot/system messages).
    *   Added `mark_messages_as_read` CRUD function to update status when a conversation is viewed.

2.  **Polling Mechanism**:
    *   Implemented a `QTimer` in the UI to periodically poll for new unread messages from non-user senders using a new CRUD function `count_unread_bot_messages`.

3.  **Desktop Notifications**:
    *   Integrated `QSystemTrayIcon` to display desktop notifications when the polling mechanism detects new unread messages.
    *   Clicking the tray icon attempts to bring the application window to the front.

4.  **UI Visual Indicators**:
    *   Conversations in the list with unread messages are now visually distinguished (bolded and marked with "[UNREAD]").
    *   A new CRUD function `has_unread_bot_messages` checks per-conversation unread status.
    *   Selecting a conversation marks its messages as read and updates its visual style in the list.
    *   The conversation list is refreshed when the global unread state changes.

5.  **Unit Tests**:
    *   Added comprehensive unit tests for the new CRUD functions and UI logic related to read status, polling, notification triggering, and visual indicators.

These enhancements provide you with timely alerts and clear visual cues for new messages, improving the overall user experience of the chat integration.