### PR TITLE
Fix: Correct NameError for main_splitter in main_window.py

### DIFF
--- a/db/__init__.py
+++ b/db/__init__.py
@@ -189,6 +189,10 @@ from .cruds.partners_crud import (
     delete_partner_category,
     update_partner_category,
     get_partner_category_by_id, # Added
+    add_partner_interaction,
+    get_interactions_for_partner,
+    update_partner_interaction,
+    delete_partner_interaction,
 )
 from .cruds.locations_crud import get_all_countries, add_country, get_or_add_country, get_all_cities, add_city, get_or_add_city, get_country_by_id, get_city_by_id, get_country_by_name, get_city_by_name_and_country_id
 from .cruds.transporters_crud import get_all_transporters, add_transporter, get_transporter_by_id, update_transporter, delete_transporter
@@ -362,6 +366,10 @@ __all__ = [
     "delete_partner_category",
     "update_partner_category",
     "get_partner_category_by_id", # Added
+    "add_partner_interaction",
+    "get_interactions_for_partner",
+    "update_partner_interaction",
+    "delete_partner_interaction",
     "get_all_countries",
     "add_country",
     "get_or_add_country",

--- a/main_window.py
+++ b/main_window.py
@@ -284,7 +284,7 @@ class DocumentManager(QMainWindow):
 
         # map_group_box removed from here
         left_pane_widget.setLayout(left_pane_layout)
-        main_splitter.addWidget(left_pane_widget)
+        self.main_splitter.addWidget(left_pane_widget)
 
         # Right pane for client tabs (no change here, it's a QSplitter itself)
         right_pane_splitter = QSplitter(Qt.Vertical)


### PR DESCRIPTION
The variable main_splitter was referenced without 'self.' in the setup_ui_main method, causing a NameError. It was defined as an instance variable self.main_splitter.

This change corrects the reference to self.main_splitter, resolving the NameError.