### PR TITLE
Fix: Add missing table definitions and correct schema order

### DIFF
--- a/db/init_schema.py
+++ b/db/init_schema.py
@@ -1292,6 +1292,158 @@ CREATE TABLE IF NOT EXISTS Templates (
             UNIQUE (user_google_account_id, google_contact_id)
         )""")
 
+    # ReportConfigurations Table
+    cursor.execute("""
+    CREATE TABLE IF NOT EXISTS ReportConfigurations (
+        report_config_id TEXT PRIMARY KEY, -- UUID
+        report_name TEXT NOT NULL UNIQUE,
+        description TEXT,
+        target_entity TEXT NOT NULL, -- e.g., 'Assets', 'Clients', 'Projects'
+        output_format TEXT NOT NULL, -- e.g., 'PDF', 'CSV', 'JSON'
+        created_by_user_id TEXT,
+        created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+        updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+        is_system_report BOOLEAN DEFAULT FALSE,
+        FOREIGN KEY (created_by_user_id) REFERENCES Users (user_id) ON DELETE SET NULL
+    )
+    """)
+
+    # ReportConfigFields Table
+    cursor.execute("""
+    CREATE TABLE IF NOT EXISTS ReportConfigFields (
+        report_config_field_id INTEGER PRIMARY KEY AUTOINCREMENT,
+        report_config_id TEXT NOT NULL,
+        field_name TEXT NOT NULL, -- Original field name from the entity
+        display_name TEXT,        -- Custom display name for the report
+        sort_order INTEGER DEFAULT 0,     -- 0 for no sort, 1 for primary sort, 2 for secondary, etc.
+        sort_direction TEXT,      -- 'ASC' or 'DESC', NULL if not sorted
+        group_by_priority INTEGER DEFAULT 0, -- 0 for no group, 1 for primary group, etc.
+        FOREIGN KEY (report_config_id) REFERENCES ReportConfigurations (report_config_id) ON DELETE CASCADE
+    )
+    """)
+
+    # ReportConfigFilters Table
+    cursor.execute("""
+    CREATE TABLE IF NOT EXISTS ReportConfigFilters (
+        report_config_filter_id INTEGER PRIMARY KEY AUTOINCREMENT,
+        report_config_id TEXT NOT NULL,
+        field_name TEXT NOT NULL,
+        operator TEXT NOT NULL, -- e.g., '=', '!=', '>', '<', 'IN', 'NOT IN', 'LIKE', 'BETWEEN'
+        filter_value_1 TEXT,    -- Primary value, or start value for BETWEEN
+        filter_value_2 TEXT,    -- End value for BETWEEN, NULL otherwise
+        logical_group TEXT DEFAULT 'AND', -- 'AND' or 'OR' for grouping with next filter
+        FOREIGN KEY (report_config_id) REFERENCES ReportConfigurations (report_config_id) ON DELETE CASCADE
+    )
+    """)
+
+    # ItemLocations Table
+    cursor.execute("""
+    CREATE TABLE IF NOT EXISTS ItemLocations (
+        location_id TEXT PRIMARY KEY,
+        location_name TEXT,
+        location_type TEXT,
+        parent_location_id TEXT,
+        created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+        updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+        FOREIGN KEY (parent_location_id) REFERENCES ItemLocations(location_id) ON DELETE SET NULL
+    )
+    """)
+
+    # InternalStockItems Table
+    cursor.execute("""
+    CREATE TABLE IF NOT EXISTS InternalStockItems (
+        item_id TEXT PRIMARY KEY,
+        item_name TEXT,
+        item_code TEXT UNIQUE,
+        category TEXT,
+        description TEXT,
+        quantity REAL DEFAULT 0,
+        unit_of_measure TEXT,
+        created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+        updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+    )
+    """)
+
+    # ItemStorageLocations Table
+    cursor.execute("""
+    CREATE TABLE IF NOT EXISTS ItemStorageLocations (
+        item_storage_location_id TEXT PRIMARY KEY,
+        item_id TEXT,
+        location_id TEXT,
+        quantity_at_location REAL DEFAULT 0,
+        last_updated TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+        FOREIGN KEY (item_id) REFERENCES InternalStockItems(item_id) ON DELETE CASCADE,
+        FOREIGN KEY (location_id) REFERENCES ItemLocations(location_id) ON DELETE CASCADE,
+        UNIQUE (item_id, location_id)
+    )
+    """)
+
+    # ProductStorageLocations Table
+    cursor.execute("""
+    CREATE TABLE IF NOT EXISTS ProductStorageLocations (
+        product_storage_location_id TEXT PRIMARY KEY,
+        product_id INTEGER,
+        location_id TEXT,
+        quantity_at_location REAL DEFAULT 0,
+        last_updated TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+        FOREIGN KEY (product_id) REFERENCES Products(product_id) ON DELETE CASCADE,
+        FOREIGN KEY (location_id) REFERENCES ItemLocations(location_id) ON DELETE CASCADE,
+        UNIQUE (product_id, location_id)
+    )
+    """)
+
+    # CompanyAssets Table
+    cursor.execute("""
+    CREATE TABLE IF NOT EXISTS CompanyAssets (
+        asset_id TEXT PRIMARY KEY, -- UUID
+        asset_name TEXT NOT NULL,
+        asset_type TEXT NOT NULL,
+        serial_number TEXT UNIQUE,
+        description TEXT,
+        purchase_date DATE,
+        purchase_value REAL,
+        current_status TEXT NOT NULL,
+        notes TEXT,
+        created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+        updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+        is_deleted INTEGER DEFAULT 0,
+        deleted_at TIMESTAMP
+    )
+    """)
+
+    # AssetAssignments Table
+    cursor.execute("""
+    CREATE TABLE IF NOT EXISTS AssetAssignments (
+        assignment_id TEXT PRIMARY KEY, -- UUID
+        asset_id TEXT NOT NULL,
+        personnel_id INTEGER NOT NULL,
+        assignment_date TIMESTAMP NOT NULL,
+        expected_return_date TIMESTAMP,
+        actual_return_date TIMESTAMP,
+        assignment_status TEXT NOT NULL,
+        notes TEXT,
+        created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+        updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+        FOREIGN KEY (asset_id) REFERENCES CompanyAssets (asset_id) ON DELETE CASCADE,
+        FOREIGN KEY (personnel_id) REFERENCES CompanyPersonnel (personnel_id) ON DELETE RESTRICT
+    )
+    """)
+
+    # AssetMediaLinks Table
+    cursor.execute("""
+    CREATE TABLE IF NOT EXISTS AssetMediaLinks (
+        link_id INTEGER PRIMARY KEY AUTOINCREMENT,
+        asset_id TEXT NOT NULL,
+        media_item_id TEXT NOT NULL,
+        display_order INTEGER DEFAULT 0,
+        alt_text TEXT,
+        created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+        FOREIGN KEY (asset_id) REFERENCES CompanyAssets (asset_id) ON DELETE CASCADE,
+        FOREIGN KEY (media_item_id) REFERENCES MediaItems (media_item_id) ON DELETE CASCADE,
+        UNIQUE (asset_id, media_item_id),
+        UNIQUE (asset_id, display_order)
+    )
+    """)
 
     # --- Indexes (Consolidated from ca.py and schema.py) ---
     # Clients
@@ -1433,104 +1585,6 @@ CREATE TABLE IF NOT EXISTS Templates (
     # ProductStorageLocations
     cursor.execute("CREATE INDEX IF NOT EXISTS idx_productstoragelocations_product_id ON ProductStorageLocations(product_id)")
     cursor.execute("CREATE INDEX IF NOT EXISTS idx_productstoragelocations_location_id ON ProductStorageLocations(location_id)")
-
-    # CompanyAssets Table
-    cursor.execute("""
-    CREATE TABLE IF NOT EXISTS CompanyAssets (
-        asset_id TEXT PRIMARY KEY, -- UUID
-        asset_name TEXT NOT NULL,
-        asset_type TEXT NOT NULL,
-        serial_number TEXT UNIQUE,
-        description TEXT,
-        purchase_date DATE,
-        purchase_value REAL,
-        current_status TEXT NOT NULL,
-        notes TEXT,
-        created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
-        updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
-        is_deleted INTEGER DEFAULT 0,
-        deleted_at TIMESTAMP
-    )
-    """)
-
-    # AssetAssignments Table
-    cursor.execute("""
-    CREATE TABLE IF NOT EXISTS AssetAssignments (
-        assignment_id TEXT PRIMARY KEY, -- UUID
-        asset_id TEXT NOT NULL,
-        personnel_id INTEGER NOT NULL,
-        assignment_date TIMESTAMP NOT NULL,
-        expected_return_date TIMESTAMP,
-        actual_return_date TIMESTAMP,
-        assignment_status TEXT NOT NULL,
-        notes TEXT,
-        created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
-        updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
-        FOREIGN KEY (asset_id) REFERENCES CompanyAssets (asset_id) ON DELETE CASCADE,
-        FOREIGN KEY (personnel_id) REFERENCES CompanyPersonnel (personnel_id) ON DELETE RESTRICT
-    )
-    """)
-
-    # AssetMediaLinks Table
-    cursor.execute("""
-    CREATE TABLE IF NOT EXISTS AssetMediaLinks (
-        link_id INTEGER PRIMARY KEY AUTOINCREMENT,
-        asset_id TEXT NOT NULL,
-        media_item_id TEXT NOT NULL,
-        display_order INTEGER DEFAULT 0,
-        alt_text TEXT,
-        created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
-        FOREIGN KEY (asset_id) REFERENCES CompanyAssets (asset_id) ON DELETE CASCADE,
-        FOREIGN KEY (media_item_id) REFERENCES MediaItems (media_item_id) ON DELETE CASCADE,
-        UNIQUE (asset_id, media_item_id),
-        UNIQUE (asset_id, display_order)
-    )
-    """)
-
-    # ReportConfigurations Table
-    cursor.execute("""
-    CREATE TABLE IF NOT EXISTS ReportConfigurations (
-        report_config_id TEXT PRIMARY KEY, -- UUID
-        report_name TEXT NOT NULL UNIQUE,
-        description TEXT,
-        target_entity TEXT NOT NULL, -- e.g., 'Assets', 'Clients', 'Projects'
-        output_format TEXT NOT NULL, -- e.g., 'PDF', 'CSV', 'JSON'
-        created_by_user_id TEXT,
-        created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
-        updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
-        is_system_report BOOLEAN DEFAULT FALSE,
-        FOREIGN KEY (created_by_user_id) REFERENCES Users (user_id) ON DELETE SET NULL
-    )
-    """)
-
-    # ReportConfigFields Table
-    cursor.execute("""
-    CREATE TABLE IF NOT EXISTS ReportConfigFields (
-        report_config_field_id INTEGER PRIMARY KEY AUTOINCREMENT,
-        report_config_id TEXT NOT NULL,
-        field_name TEXT NOT NULL, -- Original field name from the entity
-        display_name TEXT,        -- Custom display name for the report
-        sort_order INTEGER DEFAULT 0,     -- 0 for no sort, 1 for primary sort, 2 for secondary, etc.
-        sort_direction TEXT,      -- 'ASC' or 'DESC', NULL if not sorted
-        group_by_priority INTEGER DEFAULT 0, -- 0 for no group, 1 for primary group, etc.
-        FOREIGN KEY (report_config_id) REFERENCES ReportConfigurations (report_config_id) ON DELETE CASCADE
-    )
-    """)
-
-    # ReportConfigFilters Table
-    cursor.execute("""
-    CREATE TABLE IF NOT EXISTS ReportConfigFilters (
-        report_config_filter_id INTEGER PRIMARY KEY AUTOINCREMENT,
-        report_config_id TEXT NOT NULL,
-        field_name TEXT NOT NULL,
-        operator TEXT NOT NULL, -- e.g., '=', '!=', '>', '<', 'IN', 'NOT IN', 'LIKE', 'BETWEEN'
-        filter_value_1 TEXT,    -- Primary value, or start value for BETWEEN
-        filter_value_2 TEXT,    -- End value for BETWEEN, NULL otherwise
-        logical_group TEXT DEFAULT 'AND', -- 'AND' or 'OR' for grouping with next filter
-        FOREIGN KEY (report_config_id) REFERENCES ReportConfigurations (report_config_id) ON DELETE CASCADE
-    )
-    """)
-
 
     # ProformaInvoices
     cursor.execute("CREATE INDEX IF NOT EXISTS idx_proforma_invoices_proforma_invoice_number ON proforma_invoices(proforma_invoice_number)")


### PR DESCRIPTION
Added CREATE TABLE statements for ItemLocations, InternalStockItems, ItemStorageLocations, and ProductStorageLocations in db/init_schema.py as they were previously missing, causing 'no such table' errors during index creation.

Also reordered the CREATE TABLE statements for CompanyAssets, AssetAssignments, AssetMediaLinks, and the previously fixed ReportConfigurations, ReportConfigFields, and ReportConfigFilters to ensure all tables are defined before the main indexing section in db/init_schema.py.

This comprehensive reordering and addition should resolve the sqlite3.OperationalError issues related to table/index creation order.