### PR TITLE
Refactor: Adjust client list and details pane default widths

### DIFF
--- a/main_window.py
+++ b/main_window.py
@@ -406,8 +406,8 @@ class DocumentManager(QMainWindow):
                 logging.error(f"Error restoring splitter state: {e}. Applying defaults.", exc_info=True)
                 self.main_splitter.setSizes([int(self.width() * 0.20), int(self.width() * 0.80)])
         else:
-            self.main_splitter.setSizes([int(self.width() * 0.20), int(self.width() * 0.80)])
-            logging.info("Client list splitter: No saved state found, applied default sizes.")
+            self.main_splitter.setSizes([int(self.width() * 0.15), int(self.width() * 0.85)])
+            logging.info("Client list splitter: No saved state found, applied default sizes 15/85.")
 
         self.main_splitter.splitterMoved.connect(self.save_splitter_state)
 


### PR DESCRIPTION
The default width for the client list pane in the main window's splitter has been reduced from 20% to 15% of the total width. Consequently, the client details pane now defaults to 85% of the width.

This change provides more screen real estate to the client details view by default, addressing your feedback for better space allocation. You can still manually resize the splitter, and your preference will be saved and loaded on subsequent sessions.

No changes were made to the client detail display functionality itself, as it already meets the requirement of showing details upon client selection.