### PR TITLE
Fix: Correct import for get_db_connection

### DIFF
--- a/db/cruds/company_assets_crud.py
+++ b/db/cruds/company_assets_crud.py
@@ -5,7 +5,7 @@ from datetime import datetime, timezone, timedelta
 from typing import Optional, List, Dict, Any
 
 
-from ..database_manager import get_db_connection
+from ..connection import get_db_connection
 from .generic_crud import GenericCRUD # Assuming GenericCRUD has _manage_conn
 
 # Configure logging


### PR DESCRIPTION
Resolved a ModuleNotFoundError in db.cruds.company_assets_crud. The import for `get_db_connection` was pointing to a non-existent `database_manager` module.

Changed the import from `..database_manager` to `..connection` to correctly reference the module containing the database connection function.