### PR TITLE
Fix: Add __init__ to GenericCRUD to resolve TypeError

### DIFF
--- a/db/cruds/company_assets_crud.py
+++ b/db/cruds/company_assets_crud.py
@@ -5,7 +5,7 @@ from datetime import datetime, timezone, timedelta
 from typing import Optional, List, Dict, Any
 
 
-from ..database_manager import get_db_connection
+from ..connection import get_db_connection
 from .generic_crud import GenericCRUD # Assuming GenericCRUD has _manage_conn
 
 # Configure logging

--- a/db/cruds/generic_crud.py
+++ b/db/cruds/generic_crud.py
@@ -56,6 +56,10 @@ def _manage_conn(func):
 
 # Generic CRUD Base Class
 class GenericCRUD:
+    def __init__(self, table_name=None, primary_key=None, db_path=None):
+        self.table_name = table_name
+        self.primary_key = primary_key
+        self.db_path = db_path
     """
     A base class providing generic CRUD (Create, Read, Update, Delete) operations
     that can be inherited by specific CRUD classes for different database tables.


### PR DESCRIPTION
Added an __init__ method to the GenericCRUD class to allow it to be initialized with table_name, primary_key, and db_path arguments. This resolves a TypeError that occurred when CompanyAssetsCRUD (and potentially other subclasses) called super().__init__(...) with these parameters, as GenericCRUD was previously inheriting object.__init__ which takes no such arguments.

The new __init__ method in GenericCRUD now stores these parameters as instance attributes. This change is based on the apparent design intention of subclasses like CompanyAssetsCRUD.