### PR TITLE
Fix: Resolve ImportError for tags_crud

### DIFF
--- a/db/cruds/__init__.py
+++ b/db/cruds/__init__.py
@@ -31,6 +31,7 @@ from . import product_media_links_crud
 from . import products_crud
 from . import projects_crud
 from . import status_settings_crud
+from . import tags_crud
 from . import tasks_crud
 from . import team_members_crud
 from . import template_categories_crud

--- a/db/cruds/tags_crud.py
+++ b/db/cruds/tags_crud.py
@@ -1,0 +1,29 @@
+# db/cruds/tags_crud.py
+"""
+This module will contain CRUD operations for tags.
+"""
+
+def create_tag(db_session, tag_data: dict):
+    # Placeholder for creating a tag
+    print(f"Placeholder: Creating tag with data: {tag_data}")
+    return None
+
+def get_tag(db_session, tag_id: int):
+    # Placeholder for getting a single tag by id
+    print(f"Placeholder: Getting tag with id: {tag_id}")
+    return None
+
+def get_tags(db_session, skip: int = 0, limit: int = 100):
+    # Placeholder for getting multiple tags
+    print(f"Placeholder: Getting tags with skip={skip}, limit={limit}")
+    return []
+
+def update_tag(db_session, tag_id: int, tag_data: dict):
+    # Placeholder for updating a tag
+    print(f"Placeholder: Updating tag with id: {tag_id} with data: {tag_data}")
+    return None
+
+def delete_tag(db_session, tag_id: int):
+    # Placeholder for deleting a tag
+    print(f"Placeholder: Deleting tag with id: {tag_id}")
+    return None


### PR DESCRIPTION
I created a placeholder file `db/cruds/tags_crud.py` and updated `db/cruds/__init__.py` to include the necessary import.

This addresses the `ImportError: cannot import name 'tags_crud' from 'db.cruds'` that occurred when `experience_module_widget.py` attempted to import `tags_crud`. The new file contains placeholder CRUD functions for tags, allowing your application to import the module successfully. Further implementation of tag-related CRUD operations will be handled separately.