### PR TITLE
Fix: Handle missing media_items_crud import gracefully

### DIFF
--- a/db/cruds/__init__.py
+++ b/db/cruds/__init__.py
@@ -1,4 +1,6 @@
 # db/cruds/__init__.py
+import logging # Added logging import
+
 from . import activity_logs_crud
 from . import application_settings_crud
 from . import client_assigned_personnel_crud # Added
@@ -39,6 +41,12 @@ from . import templates_crud
 from . import transporters_crud # Added
 from . import money_transfer_agents_crud # Added
 from . import users_crud
+
+try:
+    from . import media_items_crud
+except ImportError:
+    media_items_crud = None
+    logging.warning("db.cruds.media_items_crud module not found. Media item functionality will be limited.")
 
 # Recruitment CRUDs
 from . import recruitment_job_openings_crud


### PR DESCRIPTION
Resolves an ImportError when starting the application due to the missing db.cruds.media_items_crud module.

The db/cruds/__init__.py file has been modified to:
- Attempt to import media_items_crud.
- If an ImportError occurs, set media_items_crud to None.
- Log a warning message indicating that the module is missing and media item functionality will be limited.

This allows the application to start and operate with reduced media functionality, preventing a crash. The underlying issue of the missing media_items_crud module and its functionality still needs to be addressed separately.