### PR TITLE
feat: Prepare application for database backend flexibility

### DIFF
--- a/db/connection.py
+++ b/db/connection.py
@@ -18,20 +18,105 @@ def get_db_connection(db_path_override=None):
         path_to_connect = db_path_override
     else:
         app_config = app_setup.get_app_config()
-        path_to_connect = app_config.get('database_path')
+        path_to_connect = app_config.get('database_path') # Used by SQLite and potentially others
+        database_type = app_config.get('database_type', 'sqlite') # Default to 'sqlite' if not set
 
-        if not path_to_connect: # Check if it's None or empty
-            # This is a critical error because utils.load_config should always provide a default.
-            # If it's missing here, something is fundamentally wrong with config loading.
+        if not path_to_connect and database_type == 'sqlite': # Path is critical for SQLite if no override
             logging.critical(
-                "CRITICAL: 'database_path' is missing or empty in the application configuration (app_setup.CONFIG). "
-                "This path is essential for database connectivity. "
-                "Please check the configuration setup and ensure 'utils.load_config' provides a default."
+                "CRITICAL: 'database_path' is missing or empty in the application configuration for SQLite. "
+                "This path is essential for SQLite database connectivity. "
+                "Please check the configuration setup."
             )
-            raise ValueError("Database path not found in application configuration. Cannot establish connection.")
+            raise ValueError("SQLite database path not found in application configuration. Cannot establish connection.")
 
-    conn = sqlite3.connect(path_to_connect)
-    conn.row_factory = sqlite3.Row
-    return conn
+    if database_type == 'sqlite':
+        if not path_to_connect: # Should be caught above if db_path_override is also None, but as a safeguard.
+            raise ValueError("SQLite connection requires a valid database path.")
+        conn = sqlite3.connect(path_to_connect)
+        conn.row_factory = sqlite3.Row
+        return conn
+    elif database_type == 'postgresql':
+        # --- PostgreSQL Connection (Not Implemented) ---
+        # This section is reserved for PostgreSQL database connection logic.
+        #
+        # To implement PostgreSQL support:
+        # 1. Install the PostgreSQL database driver:
+        #    pip install psycopg2-binary (or psycopg2)
+        # 2. Import the driver at the top of this file:
+        #    import psycopg2
+        # 3. Replace the NotImplementedError below with connection code.
+        #
+        # Required connection parameters (typically sourced from app_config):
+        #   - host:     Hostname or IP address of the PostgreSQL server (e.g., app_config.get('db_host', 'localhost'))
+        #   - port:     Port number (e.g., app_config.get('db_port', 5432))
+        #   - user:     Database username (e.g., app_config.get('db_user'))
+        #   - password: User's password (e.g., app_config.get('db_password'))
+        #   - dbname:   Name of the database (e.g., app_config.get('db_name'))
+        #
+        # Example connection:
+        #   try:
+        #       conn = psycopg2.connect(
+        #           host=app_config.get('db_host', 'localhost'),
+        #           dbname=app_config.get('db_name'),
+        #           user=app_config.get('db_user'),
+        #           password=app_config.get('db_password'),
+        #           port=int(app_config.get('db_port', 5432)) # Ensure port is an integer
+        #       )
+        #       # Optionally, set conn.row_factory or other session parameters
+        #       return conn
+        #   except psycopg2.Error as e:
+        #       logging.error(f"PostgreSQL connection error: {e}")
+        #       raise ConnectionError(f"Failed to connect to PostgreSQL database: {e}") # Or handle more gracefully
+        #
+        # The 'path_to_connect' variable (derived from 'database_path' in config) is typically
+        # not used directly by PostgreSQL, as connection is usually via network parameters.
+        raise NotImplementedError(
+            "PostgreSQL connection not yet implemented. "
+            "Please configure in db/connection.py within the 'postgresql' block and install the 'psycopg2' driver."
+        )
+    elif database_type == 'mysql':
+        # --- MySQL Connection (Not Implemented) ---
+        # This section is reserved for MySQL database connection logic.
+        #
+        # To implement MySQL support:
+        # 1. Install the MySQL database driver:
+        #    pip install mysql-connector-python
+        # 2. Import the driver at the top of this file:
+        #    import mysql.connector
+        # 3. Replace the NotImplementedError below with connection code.
+        #
+        # Required connection parameters (typically sourced from app_config):
+        #   - host:     Hostname or IP address of the MySQL server (e.g., app_config.get('db_host', 'localhost'))
+        #   - port:     Port number (e.g., app_config.get('db_port', 3306))
+        #   - user:     Database username (e.g., app_config.get('db_user'))
+        #   - password: User's password (e.g., app_config.get('db_password'))
+        #   - database: Name of the database (e.g., app_config.get('db_name'))
+        #
+        # Example connection:
+        #   try:
+        #       conn = mysql.connector.connect(
+        #           host=app_config.get('db_host', 'localhost'),
+        #           database=app_config.get('db_name'),
+        #           user=app_config.get('db_user'),
+        #           password=app_config.get('db_password'),
+        #           port=int(app_config.get('db_port', 3306)) # Ensure port is an integer
+        #       )
+        #       # For MySQL with mysql-connector-python, to get dict-like rows (similar to sqlite3.Row):
+        #       # cursor = conn.cursor(dictionary=True)
+        #       # However, the connection object itself is returned here. Row factory is usually set on cursor.
+        #       # This function is expected to return a connection object.
+        #       # Adapting to a common row_factory pattern might require changes to how cursors are handled.
+        #       return conn
+        #   except mysql.connector.Error as e:
+        #       logging.error(f"MySQL connection error: {e}")
+        #       raise ConnectionError(f"Failed to connect to MySQL database: {e}") # Or handle more gracefully
+        #
+        # The 'path_to_connect' variable is typically not used directly by MySQL.
+        raise NotImplementedError(
+            "MySQL connection not yet implemented. "
+            "Please configure in db/connection.py within the 'mysql' block and install the 'mysql-connector-python' driver."
+        )
+    else:
+        raise ValueError(f"Unsupported database_type: '{database_type}'. Please check configuration.")
 
 __all__ = ["get_db_connection"]

--- a/utils.py
+++ b/utils.py
@@ -43,15 +43,19 @@ def load_config(app_root_dir, default_templates_dir, default_clients_dir):
     if os.path.exists(config_path):
         try:
             with open(config_path, "r", encoding="utf-8") as f:
-                return json.load(f)
+                user_config = json.load(f)
+                # Ensure 'database_type' defaults to 'sqlite' if not present
+                user_config.setdefault('database_type', 'sqlite')
+                return user_config
         except (IOError, json.JSONDecodeError) as e:
             print(f"Error loading config: {e}. Using defaults.")
 
     # If config file doesn't exist or is invalid, return defaults
-    return {
+    default_config = {
         "templates_dir": default_templates_dir, # Use passed default
         "clients_dir": default_clients_dir,     # Use passed default
         "database_path": os.path.join(app_root_dir, "app_data.db"),
+        "database_type": "sqlite", # Ensure default is sqlite
         "language": "fr",
         "smtp_server": "",
         "smtp_port": 587,
@@ -61,6 +65,7 @@ def load_config(app_root_dir, default_templates_dir, default_clients_dir):
         "download_monitor_enabled": False,
         "download_monitor_path": os.path.join(os.path.expanduser('~'), 'Downloads')
     }
+    return default_config
 
 def save_config(config_data):
     try:


### PR DESCRIPTION
This commit introduces changes to allow for easier integration of different database backends in the future, while retaining SQLite as the current default and only supported option.

Key changes:

- Added a "Database Type" selector in the settings page (`settings_page.py`). Currently, it defaults to SQLite and includes placeholders for PostgreSQL and MySQL to indicate future extensibility.
- The application configuration now includes a `database_type` setting, which defaults to 'sqlite' if not specified (`utils.py`).
- The database connection logic (`db/connection.py`) has been refactored to read the `database_type` from the configuration. It includes conditional blocks for SQLite (functional) and raises `NotImplementedError` for PostgreSQL and MySQL, with comments guiding future implementation.
- The existing "Database Path" setting remains and is used by SQLite. It can be repurposed for connection strings or host details for other database types in the future.

These changes do not alter the current database functionality (still SQLite) but provide the necessary framework for future expansion to other database systems by primarily modifying `db/connection.py` and adding relevant UI options/configuration parameters.