### PR TITLE
Add initial splash screen functionality

### DIFF
--- a/main.py
+++ b/main.py
@@ -7,7 +7,7 @@ import icons_rc # Import the compiled resource file
 # Core PyQt5 imports for application execution
 from PyQt5.QtWidgets import QApplication
 from PyQt5.QtCore import QLocale, QLibraryInfo, QTranslator, Qt
-from PyQt5.QtGui import QFont
+from PyQt5.QtGui import QFont, QSplashScreen, QPixmap
 
 # Imports from project structure
 from app_setup import (
@@ -102,6 +102,12 @@ def main():
 
     # 4. Create QApplication Instance
     app = QApplication(sys.argv)
+
+    # Display Splash Screen
+    splash_pix = QPixmap(os.path.join(APP_ROOT_DIR, "icons", "leopard_logo.svg"))
+    splash = QSplashScreen(splash_pix, Qt.WindowStaysOnTopHint | Qt.FramelessWindowHint)
+    splash.show()
+    app.processEvents() # Ensure splash screen is displayed promptly
 
     # 5. Set Application Name and Style
     app.setApplicationName("ClientDocManager")
@@ -433,44 +439,47 @@ def main():
         QApplication.instance().notification_manager = notification_manager
 
         main_window.show()
+        splash.finish(main_window) # Close splash screen
         logging.info("Main window shown. Application is running.")
         sys.exit(app.exec_())
     else:
         # This path should ideally not be reached if logic is correct,
         # as either proceed_to_main_app is true or sys.exit() was called.
         logging.error("Fatal error in authentication flow. Application cannot start.")
+        splash.hide() # Ensure splash screen is hidden on error
         sys.exit(1)
 
-    login_dialog = LoginWindow() # Create LoginWindow instance
-    login_result = login_dialog.exec_() # Show login dialog modally
-
-    if login_result == QDialog.Accepted:
-        session_token = login_dialog.get_session_token()
-        logged_in_user = login_dialog.get_current_user()
-
-        CURRENT_SESSION_TOKEN = session_token
-        if logged_in_user:
-            CURRENT_USER_ROLE = logged_in_user.get('role')
-            CURRENT_USER_ID = logged_in_user.get('user_id')
-            # Set session start time
-            SESSION_START_TIME = datetime.datetime.now()
-            logging.info(f"Login successful. User: {logged_in_user.get('username')}, Role: {CURRENT_USER_ROLE}, Token: {CURRENT_SESSION_TOKEN}, Session started: {SESSION_START_TIME}")
-        else:
-            logging.error("Login reported successful, but no user data retrieved. Exiting.")
-            sys.exit(1)
-
-        # 11. Create and Show Main Window (only after successful login)
-        # DocumentManager is imported from main_window
-        # APP_ROOT_DIR is imported from app_setup
-        main_window = DocumentManager(APP_ROOT_DIR, CURRENT_USER_ID) # Pass user_id and role if needed by DocumentManager
-        main_window.show()
-        logging.info("Main window shown. Application is running.")
-
-        # 12. Execute Application
-        sys.exit(app.exec_())
-    else:
-        logging.info("Login failed or cancelled. Exiting application.")
-        sys.exit() # Exit if login is not successful
+    # The following block seems redundant due to the logic above,
+    # but if it's reached, ensure splash screen is handled.
+    # Consider refactoring to avoid this redundancy.
+    # login_dialog = LoginWindow() # Create LoginWindow instance
+    # login_result = login_dialog.exec_() # Show login dialog modally
+    #
+    # if login_result == QDialog.Accepted:
+    #     session_token = login_dialog.get_session_token()
+    #     logged_in_user = login_dialog.get_current_user()
+    #
+    #     CURRENT_SESSION_TOKEN = session_token
+    #     if logged_in_user:
+    #         CURRENT_USER_ROLE = logged_in_user.get('role')
+    #         CURRENT_USER_ID = logged_in_user.get('user_id')
+    #         SESSION_START_TIME = datetime.datetime.now()
+    #         logging.info(f"Login successful. User: {logged_in_user.get('username')}, Role: {CURRENT_USER_ROLE}, Token: {CURRENT_SESSION_TOKEN}, Session started: {SESSION_START_TIME}")
+    #     else:
+    #         logging.error("Login reported successful, but no user data retrieved. Exiting.")
+    #         splash.hide()
+    #         sys.exit(1)
+    #
+    #     main_window = DocumentManager(APP_ROOT_DIR, CURRENT_USER_ID)
+    #     main_window.show()
+    #     splash.finish(main_window)
+    #     logging.info("Main window shown. Application is running.")
+    #
+    #     sys.exit(app.exec_())
+    # else:
+    #     logging.info("Login failed or cancelled. Exiting application.")
+    #     splash.hide()
+    #     sys.exit()
 
 def get_notification_manager():
     """


### PR DESCRIPTION
Implements a splash screen that appears during application startup.
- Uses `QSplashScreen` to display an image.
- Currently uses `icons/leopard_logo.svg` as a placeholder image. You intend to replace this with a custom animated GIF.
- The splash screen is configured to be frameless and stay on top.
- It correctly closes when the main application window (`DocumentManager`) is shown or if an error occurs during the startup sequence.
- Also includes a minor cleanup by commenting out a redundant block of `LoginWindow` instantiation code in `main.py`.