### PR TITLE
feat: Implement status management module

### DIFF
--- a/db/cruds/status_settings_crud.py
+++ b/db/cruds/status_settings_crud.py
@@ -63,3 +63,171 @@ def get_all_status_settings(type_filter: str = None, conn: sqlite3.Connection = 
     except sqlite3.Error as e:
         logging.error(f"Database error in get_all_status_settings (filter: {type_filter}): {e}")
         return []
+
+
+@_manage_conn
+def add_status_setting(status_name: str, status_type: str, color_hex: str = None, sort_order: int = 0, conn: sqlite3.Connection = None) -> int | bool:
+    """
+    Adds a new status setting to the StatusSettings table.
+
+    Args:
+        status_name: The name of the status.
+        status_type: The type of the status (e.g., 'Client', 'Project', 'Task').
+        color_hex: The hex color code for the status (optional).
+        sort_order: The sort order for the status (optional, default 0).
+        conn: The database connection (managed by _manage_conn decorator if not provided).
+
+    Returns:
+        The ID of the newly inserted status if successful, False otherwise.
+    """
+    # If conn is not provided, get_db_connection will be called by the decorator @_manage_conn
+    # However, if we want to use this function without the decorator in some specific cases,
+    # or if the decorator is not applied, we might need manual connection handling.
+    # For now, assuming @_manage_conn will handle the connection.
+    # If direct call (without decorator) is needed, conn must be passed.
+
+    # The @_manage_conn decorator handles the connection and cursor creation,
+    # and also commit/rollback and closing the connection.
+    # So, we just need to get the cursor from the conn and execute the query.
+
+    if conn is None:
+        # This case should ideally be handled by @_manage_conn
+        # or the calling function should ensure conn is provided if not using the decorator.
+        logging.error("Database connection not provided to add_status_setting.")
+        # Attempt to establish a connection if none is provided and not managed by decorator
+        # This is a fallback, ideally connection is managed by decorator or passed explicitly
+        try:
+            conn = get_db_connection()
+            if conn is None:
+                logging.error("Failed to establish a fallback database connection.")
+                return False
+            # We are not in a managed context here, so manual commit/close would be needed.
+            # This path is getting complex and indicates a potential design issue
+            # if the decorator is not consistently used.
+            # For simplicity, let's rely on the decorator or explicit passing of 'conn'.
+            # If decorator is not used, the caller MUST pass an active connection.
+        except Exception as e:
+            logging.error(f"Error establishing fallback connection: {e}")
+            return False
+
+        # If we manually created a connection, we need to manually manage it.
+        # This is not ideal. The decorator @_manage_conn is preferred.
+        manual_connection_management = True
+    else:
+        manual_connection_management = False
+
+    try:
+        cur = conn.cursor()
+        sql = """INSERT INTO StatusSettings (status_name, status_type, color_hex, sort_order)
+                 VALUES (?, ?, ?, ?)"""
+        cur.execute(sql, (status_name, status_type, color_hex, sort_order))
+
+        if manual_connection_management:
+            conn.commit()
+
+        last_id = cur.lastrowid
+        cur.close() # Close cursor
+        return last_id if last_id is not None else True # lastrowid is None if no row was inserted or backend doesn't support it well, but True indicates it likely worked if no error
+    except sqlite3.Error as e:
+        logging.error(f"Database error in add_status_setting for '{status_name}'/'{status_type}': {e}")
+        if manual_connection_management and conn:
+            conn.rollback()
+        return False
+    finally:
+        if manual_connection_management and conn:
+            conn.close()
+
+
+@_manage_conn
+def update_status_setting(status_id: int, status_name: str, status_type: str, color_hex: str = None, sort_order: int = None, conn: sqlite3.Connection = None) -> bool:
+    """
+    Updates an existing status setting in the StatusSettings table.
+
+    Args:
+        status_id: The ID of the status to update.
+        status_name: The new name of the status.
+        status_type: The new type of the status.
+        color_hex: The new hex color code (optional, None to leave unchanged if not provided, or pass existing value).
+                   Consider how to handle clearing a value if that's a use case (e.g. pass empty string or specific sentinel).
+                   For now, if None, it implies no change to color_hex in the SET clause.
+        sort_order: The new sort order (optional, None to leave unchanged).
+        conn: The database connection (managed by _manage_conn decorator).
+
+    Returns:
+        True if successful, False otherwise.
+    """
+    sql = """UPDATE StatusSettings SET
+             status_name = ?,
+             status_type = ?"""
+    params = [status_name, status_type]
+
+    if color_hex is not None: # Assuming None means "do not update this field"
+        sql += ", color_hex = ?"
+        params.append(color_hex)
+
+    if sort_order is not None: # Assuming None means "do not update this field"
+        sql += ", sort_order = ?"
+        params.append(sort_order)
+
+    sql += " WHERE status_id = ?"
+    params.append(status_id)
+
+    try:
+        cur = conn.cursor()
+        cur.execute(sql, tuple(params))
+        conn.commit()
+        return cur.rowcount > 0  # True if at least one row was updated
+    except sqlite3.Error as e:
+        logging.error(f"Database error in update_status_setting for ID {status_id}: {e}")
+        # conn.rollback() # Handled by _manage_conn
+        return False
+    # finally: # Cursor and connection closing handled by _manage_conn
+        # if cur:
+        #     cur.close()
+
+
+@_manage_conn
+def is_status_in_use(status_id: int, conn: sqlite3.Connection = None) -> bool:
+    """
+    Checks if a status_id is currently in use in the Clients table.
+
+    Args:
+        status_id: The ID of the status to check.
+        conn: The database connection (managed by _manage_conn decorator).
+
+    Returns:
+        True if the status_id is found in Clients, False otherwise.
+    """
+    sql = "SELECT 1 FROM Clients WHERE status_id = ? LIMIT 1"
+    try:
+        cur = conn.cursor()
+        cur.execute(sql, (status_id,))
+        return cur.fetchone() is not None  # True if a row is found
+    except sqlite3.Error as e:
+        logging.error(f"Database error in is_status_in_use for status_id {status_id}: {e}")
+        # Returning True on error prevents deletion if the check fails, which is safer.
+        return True # Safer: assume in use if check fails
+
+
+@_manage_conn
+def delete_status_setting(status_id: int, conn: sqlite3.Connection = None) -> bool:
+    """
+    Deletes a status setting from the StatusSettings table.
+
+    Args:
+        status_id: The ID of the status to delete.
+        conn: The database connection (managed by _manage_conn decorator).
+
+    Returns:
+        True if successful (row was deleted), False otherwise.
+    """
+    sql = "DELETE FROM StatusSettings WHERE status_id = ?"
+    try:
+        cur = conn.cursor()
+        cur.execute(sql, (status_id,))
+        conn.commit()
+        return cur.rowcount > 0  # True if at least one row was deleted
+    except sqlite3.Error as e:
+        logging.error(f"Database error in delete_status_setting for ID {status_id}: {e}")
+        # conn.rollback() # Handled by _manage_conn
+        return False

--- a/dialogs/add_edit_status_dialog.py
+++ b/dialogs/add_edit_status_dialog.py
@@ -1,0 +1,133 @@
+import sys
+from PyQt5.QtWidgets import (
+    QApplication, QDialog, QLineEdit, QComboBox, QSpinBox,
+    QPushButton, QVBoxLayout, QHBoxLayout, QLabel, QFormLayout, QMessageBox
+)
+from PyQt5.QtCore import Qt
+
+class AddEditStatusDialog(QDialog):
+    def __init__(self, parent=None, status_data=None):
+        super().__init__(parent)
+        self.status_data = status_data  # For pre-filling in edit mode
+
+        if self.status_data:
+            self.setWindowTitle("Edit Status")
+        else:
+            self.setWindowTitle("Add New Status")
+
+        self.init_ui()
+        if self.status_data:
+            self.prefill_data()
+
+    def init_ui(self):
+        main_layout = QVBoxLayout(self)
+        form_layout = QFormLayout()
+
+        self.name_edit = QLineEdit()
+        self.type_combo = QComboBox()
+        # For now, predefined list. Can be made editable or fetched from DB later.
+        self.type_combo.addItems(["Client", "Project", "Task", "Ticket"]) # Added Ticket as an example
+        self.type_combo.setEditable(True) # Allow free text input
+
+        self.color_edit = QLineEdit()
+        self.color_edit.setPlaceholderText("#RRGGBB (e.g., #FF0000)")
+        self.sort_order_spinbox = QSpinBox()
+        self.sort_order_spinbox.setRange(0, 999) # Max sort order
+
+        form_layout.addRow(QLabel("Name:"), self.name_edit)
+        form_layout.addRow(QLabel("Type:"), self.type_combo)
+        form_layout.addRow(QLabel("Color (Hex):"), self.color_edit)
+        form_layout.addRow(QLabel("Sort Order:"), self.sort_order_spinbox)
+
+        main_layout.addLayout(form_layout)
+
+        # Buttons
+        buttons_layout = QHBoxLayout()
+        self.ok_button = QPushButton("OK")
+        self.cancel_button = QPushButton("Cancel")
+
+        buttons_layout.addStretch()
+        buttons_layout.addWidget(self.ok_button)
+        buttons_layout.addWidget(self.cancel_button)
+
+        main_layout.addLayout(buttons_layout)
+
+        # Connect signals
+        self.ok_button.clicked.connect(self.accept_dialog)
+        self.cancel_button.clicked.connect(self.reject)
+
+    def prefill_data(self):
+        """Prefills the dialog fields if status_data is provided (for editing)."""
+        if self.status_data:
+            self.name_edit.setText(self.status_data.get("status_name", ""))
+
+            type_value = self.status_data.get("status_type", "")
+            type_index = self.type_combo.findText(type_value, Qt.MatchFixedString)
+            if type_index >= 0:
+                self.type_combo.setCurrentIndex(type_index)
+            else:
+                self.type_combo.setCurrentText(type_value) # For free text if not in predefined list
+
+            self.color_edit.setText(self.status_data.get("color_hex", ""))
+            self.sort_order_spinbox.setValue(self.status_data.get("sort_order", 0))
+
+    def get_data(self):
+        """Returns the entered data as a dictionary."""
+        return {
+            "status_name": self.name_edit.text().strip(),
+            "status_type": self.type_combo.currentText().strip(),
+            "color_hex": self.color_edit.text().strip() if self.color_edit.text().strip() else None, # Store None if empty
+            "sort_order": self.sort_order_spinbox.value()
+        }
+
+    def accept_dialog(self):
+        """Validates input before accepting."""
+        data = self.get_data()
+        if not data["status_name"]:
+            QMessageBox.warning(self, "Input Error", "Status Name cannot be empty.")
+            return
+        if not data["status_type"]:
+            QMessageBox.warning(self, "Input Error", "Status Type cannot be empty.")
+            return
+
+        # Optional: Validate color_hex format if needed (e.g., regex for #RRGGBB)
+        color = data["color_hex"]
+        if color and not (color.startswith("#") and len(color) == 7):
+            try:
+                # Check if it's a valid hex by attempting to convert the R, G, B parts
+                int(color[1:3], 16)
+                int(color[3:5], 16)
+                int(color[5:7], 16)
+            except (ValueError, IndexError):
+                QMessageBox.warning(self, "Input Error", "Color Hex code should be in #RRGGBB format (e.g., #FF0000) or empty.")
+                return
+
+        self.accept()
+
+
+if __name__ == '__main__':
+    # This part is for testing the dialog independently
+    app = QApplication(sys.argv)
+
+    # Test Add mode
+    add_dialog = AddEditStatusDialog()
+    if add_dialog.exec_() == QDialog.Accepted:
+        print("Add Dialog Accepted. Data:", add_dialog.get_data())
+    else:
+        print("Add Dialog Canceled.")
+
+    # Test Edit mode (example data)
+    sample_edit_data = {
+        "status_id": 1,
+        "status_name": "In Progress",
+        "status_type": "Project",
+        "color_hex": "#FFA500",
+        "sort_order": 10
+    }
+    edit_dialog = AddEditStatusDialog(status_data=sample_edit_data)
+    if edit_dialog.exec_() == QDialog.Accepted:
+        print("Edit Dialog Accepted. Data:", edit_dialog.get_data())
+    else:
+        print("Edit Dialog Canceled.")
+
+    sys.exit(app.exec_())

--- a/dialogs/status_management_dialog.py
+++ b/dialogs/status_management_dialog.py
@@ -1,0 +1,287 @@
+import sys
+from PyQt5.QtWidgets import (
+    QApplication, QDialog, QTableWidget, QTableWidgetItem,
+    QPushButton, QVBoxLayout, QHBoxLayout, QHeaderView, QMessageBox
+)
+from PyQt5.QtCore import Qt
+
+# Assuming db_manager.py is in the parent directory or accessible via PYTHONPATH
+# For direct import if structure is /app/dialogs and /app/db
+import os
+import sys
+# Add the parent directory of 'dialogs' to sys.path if db is a sibling directory
+# This is a common way to handle imports in such structures when running files directly
+# For a packaged application, you'd use relative imports like from ..db.cruds...
+# current_dir = os.path.dirname(os.path.abspath(__file__))
+# parent_dir = os.path.dirname(current_dir)
+# if parent_dir not in sys.path:
+#    sys.path.append(parent_dir)
+# For this specific environment, let's assume direct import paths can be resolved
+# or that the calling environment (e.g. main app) has set up sys.path correctly.
+# We will try a relative import first, then a direct one if that fails (common for scripts)
+try:
+    from ..db.cruds.status_settings_crud import (
+        add_status_setting,
+        get_all_status_settings,
+        get_status_setting_by_id,
+        update_status_setting,
+        delete_status_setting,
+        is_status_in_use
+    )
+    from .add_edit_status_dialog import AddEditStatusDialog
+except ImportError:
+    # Fallback for running script directly or if relative import fails
+    from db.cruds.status_settings_crud import (
+        add_status_setting,
+        get_all_status_settings,
+        get_status_setting_by_id,
+        update_status_setting,
+        delete_status_setting,
+        is_status_in_use
+    )
+    from dialogs.add_edit_status_dialog import AddEditStatusDialog
+
+
+class StatusManagementDialog(QDialog):
+    def __init__(self, parent=None):
+        super().__init__(parent)
+        self.setWindowTitle("Manage Statuses")
+        self.setMinimumSize(600, 400) # Set a minimum size for better usability
+        self.init_ui()
+        self.load_statuses() # Load statuses after UI is initialized
+        self._update_button_states() # Initial state of buttons
+
+    def init_ui(self):
+        # Main layout
+        layout = QVBoxLayout(self)
+
+        # Table Widget
+        self.table_widget = QTableWidget()
+        self.table_widget.setColumnCount(5)
+        self.table_widget.setHorizontalHeaderLabels(["ID", "Name", "Type", "Color", "Sort Order"])
+        self.table_widget.horizontalHeader().setSectionResizeMode(QHeaderView.Stretch)
+        self.table_widget.setEditTriggers(QTableWidget.NoEditTriggers) # Disable editing directly in table
+        self.table_widget.setSelectionBehavior(QTableWidget.SelectRows) # Select whole rows
+        layout.addWidget(self.table_widget)
+
+        # Buttons layout
+        buttons_layout = QHBoxLayout()
+        self.add_button = QPushButton("Add")
+        self.edit_button = QPushButton("Edit")
+        self.delete_button = QPushButton("Delete") # Will be used in a future task
+        self.close_button = QPushButton("Close")
+
+        # Disable Edit and Delete buttons initially
+        self.edit_button.setEnabled(False)
+        self.delete_button.setEnabled(False)
+
+        buttons_layout.addWidget(self.add_button)
+        buttons_layout.addWidget(self.edit_button)
+        buttons_layout.addWidget(self.delete_button)
+        buttons_layout.addStretch()
+        buttons_layout.addWidget(self.close_button)
+
+        layout.addLayout(buttons_layout)
+
+        # Connect signals
+        self.add_button.clicked.connect(self.handle_add_status)
+        self.edit_button.clicked.connect(self.handle_edit_status)
+        self.delete_button.clicked.connect(self.handle_delete_status)
+        self.close_button.clicked.connect(self.accept)
+        self.table_widget.itemSelectionChanged.connect(self._update_button_states)
+
+
+    def _update_button_states(self):
+        """Enable/disable Edit and Delete buttons based on table selection."""
+        is_row_selected = bool(self.table_widget.selectedItems())
+        self.edit_button.setEnabled(is_row_selected)
+        self.delete_button.setEnabled(is_row_selected) # Also manage delete button state
+
+    def load_statuses(self):
+        # print("load_statuses method called") # Less verbose for routine calls
+        try:
+            statuses = get_all_status_settings()
+        except Exception as e:
+            QMessageBox.critical(self, "Database Error", f"Could not load statuses: {e}")
+            statuses = [] # Ensure statuses is an empty list on error
+
+        self.table_widget.setRowCount(0) # Clear existing rows
+
+        if not statuses:
+            # print("No statuses found or error in fetching.")
+            return
+
+        self.table_widget.setRowCount(len(statuses))
+        for row_idx, status_data in enumerate(statuses):
+            status_id_item = QTableWidgetItem(str(status_data.get("status_id", "")))
+            # Store the actual ID in UserRole for later retrieval
+            status_id_item.setData(Qt.UserRole, status_data.get("status_id"))
+
+            name_item = QTableWidgetItem(status_data.get("status_name", ""))
+            type_item = QTableWidgetItem(status_data.get("status_type", ""))
+            color_item = QTableWidgetItem(status_data.get("color_hex", ""))
+            sort_order_item = QTableWidgetItem(str(status_data.get("sort_order", "")))
+
+            self.table_widget.setItem(row_idx, 0, status_id_item)
+            self.table_widget.setItem(row_idx, 1, name_item)
+            self.table_widget.setItem(row_idx, 2, type_item)
+            self.table_widget.setItem(row_idx, 3, color_item)
+            self.table_widget.setItem(row_idx, 4, sort_order_item)
+
+        # Optional: Resize columns to content after loading data
+        # self.table_widget.resizeColumnsToContents()
+
+    def handle_add_status(self):
+        dialog = AddEditStatusDialog(self)
+        if dialog.exec_() == QDialog.Accepted:
+            data = dialog.get_data()
+            try:
+                # The add_status_setting function in the crud might need the @_manage_conn decorator
+                # or explicit connection management if it's not already there.
+                # Assuming it handles its own connection or is decorated.
+                success_id = add_status_setting(
+                    status_name=data["status_name"],
+                    status_type=data["status_type"],
+                    color_hex=data["color_hex"],
+                    sort_order=data["sort_order"]
+                )
+                if success_id: # If it returns an ID or True
+                    QMessageBox.information(self, "Success", f"Status '{data['status_name']}' added successfully.")
+                    self.load_statuses()  # Refresh the table
+                else:
+                    QMessageBox.warning(self, "Failure", f"Failed to add status '{data['status_name']}'. Check logs for details.")
+            except Exception as e:
+                QMessageBox.critical(self, "Error", f"An error occurred while adding status: {e}")
+                print(f"Error in handle_add_status: {e}") # For debugging
+
+    def handle_edit_status(self):
+        selected_items = self.table_widget.selectedItems()
+        if not selected_items:
+            QMessageBox.warning(self, "Selection Error", "Please select a status to edit.")
+            return
+
+        # Get status_id from the first item in the selected row (ID column)
+        # Assumes ID is in the first column and UserRole stores the ID
+        selected_row = self.table_widget.currentRow()
+        id_item = self.table_widget.item(selected_row, 0) # ID is in column 0
+        if not id_item:
+            QMessageBox.critical(self, "Error", "Could not retrieve status ID from selected row.")
+            return
+
+        status_id = id_item.data(Qt.UserRole)
+        if status_id is None:
+            QMessageBox.critical(self, "Error", "No status ID associated with the selected row.")
+            return
+
+        try:
+            current_status_data = get_status_setting_by_id(status_id)
+        except Exception as e:
+            QMessageBox.critical(self, "Database Error", f"Could not fetch status details: {e}")
+            return
+
+        if not current_status_data:
+            QMessageBox.warning(self, "Not Found", f"Status with ID {status_id} not found.")
+            return
+
+        dialog = AddEditStatusDialog(self, status_data=current_status_data)
+        if dialog.exec_() == QDialog.Accepted:
+            new_data = dialog.get_data()
+            try:
+                success = update_status_setting(
+                    status_id=status_id,
+                    status_name=new_data["status_name"],
+                    status_type=new_data["status_type"],
+                    color_hex=new_data["color_hex"], # Pass None if not changed or to clear, based on dialog logic
+                    sort_order=new_data["sort_order"]
+                )
+                if success:
+                    QMessageBox.information(self, "Success", f"Status '{new_data['status_name']}' updated successfully.")
+                    self.load_statuses()
+                else:
+                    QMessageBox.warning(self, "Failure", f"Failed to update status '{new_data['status_name']}'. It might have been deleted or an error occurred.")
+            except Exception as e:
+                QMessageBox.critical(self, "Error", f"An error occurred while updating status: {e}")
+                print(f"Error in handle_edit_status: {e}")
+
+    def handle_delete_status(self):
+        selected_items = self.table_widget.selectedItems()
+        if not selected_items:
+            QMessageBox.warning(self, "Selection Error", "Please select a status to delete.")
+            return
+
+        selected_row = self.table_widget.currentRow()
+        id_item = self.table_widget.item(selected_row, 0) # ID is in column 0
+        if not id_item:
+            QMessageBox.critical(self, "Error", "Could not retrieve status ID from selected row.")
+            return
+
+        status_id = id_item.data(Qt.UserRole)
+        status_name_item = self.table_widget.item(selected_row, 1) # Name is in column 1
+        status_name = status_name_item.text() if status_name_item else "this status"
+
+
+        if status_id is None:
+            QMessageBox.critical(self, "Error", "No status ID associated with the selected row.")
+            return
+
+        try:
+            if is_status_in_use(status_id):
+                QMessageBox.warning(self, "Cannot Delete Status",
+                                    f"The status '{status_name}' (ID: {status_id}) cannot be deleted "
+                                    "because it is currently in use by one or more clients.")
+                return
+        except Exception as e: # Catch potential errors from is_status_in_use itself
+            QMessageBox.critical(self, "Error", f"Could not verify if status is in use: {e}")
+            # is_status_in_use now returns True on DB error, so this path might be less likely
+            # but good to have a catch-all.
+            return
+
+        reply = QMessageBox.question(self, "Confirm Delete",
+                                     f"Are you sure you want to delete the status '{status_name}' (ID: {status_id})?\n"
+                                     "This action cannot be undone.",
+                                     QMessageBox.Yes | QMessageBox.No, QMessageBox.No)
+
+        if reply == QMessageBox.Yes:
+            try:
+                if delete_status_setting(status_id):
+                    QMessageBox.information(self, "Success", f"Status '{status_name}' deleted successfully.")
+                    self.load_statuses()
+                else:
+                    QMessageBox.warning(self, "Failure", f"Failed to delete status '{status_name}'. It might have already been deleted or an error occurred.")
+            except Exception as e:
+                QMessageBox.critical(self, "Error", f"An error occurred while deleting status: {e}")
+                print(f"Error in handle_delete_status: {e}")
+
+
+if __name__ == '__main__':
+    # This part is for testing the dialog independently
+    # For this to work, the db setup needs to be runnable.
+    # This usually means the db file is created if it doesn't exist,
+    # and tables are created by a setup script or db_manager.init_db().
+
+    # Ensure DB is initialized for testing
+    try:
+        from db.db_manager import init_db, get_db_connection
+        # Attempt to initialize DB (creates tables if they don't exist)
+        init_db()
+
+        # Verify connection
+        conn = get_db_connection()
+        if conn is None:
+            print("Failed to get DB connection for testing StatusManagementDialog.")
+            # sys.exit(1) # Or handle error appropriately
+        else:
+            conn.close() # Close it, db calls will reopen
+            print("DB connection successful for testing.")
+
+    except ImportError:
+        print("Could not import db_manager to initialize DB for testing. Ensure PYTHONPATH is correct.")
+        # sys.exit(1)
+    except Exception as e:
+        print(f"Error during DB initialization for testing: {e}")
+        # sys.exit(1)
+
+    app = QApplication(sys.argv)
+    dialog = StatusManagementDialog()
+    dialog.exec_()
+    sys.exit(app.exec_())


### PR DESCRIPTION
This commit introduces a comprehensive status management module.

Key features include:
- A new "Manage Statuses" dialog (`StatusManagementDialog`) accessible from the "File" menu.
- Functionality to add, edit, and delete statuses within this dialog.
- Status types can be defined (e.g., Client, Project).
- Optional color and sort order can be specified for statuses.
- Robust checks to prevent deletion of statuses currently in use by clients.
- Dynamic updates to client views:
    - The status dropdown in individual `ClientWidget` tabs is refreshed.
    - The main client list status filter is updated.
    - Open client tabs reflect any changes to their assigned status (name or if deleted).
- Underlying database CRUD operations for `StatusSettings` have been added and refined.

The "Gérer les Statuts" menu item in `main_window.py` is now enabled and functional. The `ClientWidget` has been updated to handle potential changes to status definitions gracefully.