### PR TITLE
Fix: Address multiple runtime errors and warnings

### DIFF
--- a/db/cruds/experience_crud.py
+++ b/db/cruds/experience_crud.py
@@ -69,7 +69,21 @@ def get_all_experiences(filters: dict = None, limit: int = None, offset: int = 0
         conditions = []
         for key, value in filters.items():
             if value is not None:
-                conditions.append(f"{key} = ?")
+                if key == "date_from":
+                    conditions.append("experience_date >= ?")
+                elif key == "date_to":
+                    conditions.append("experience_date <= ?")
+                # Add other specific filter key mappings here if necessary
+                # For example, if you had a 'title_like' filter:
+                # elif key == "title_like":
+                #    conditions.append("title LIKE ?")
+                #    value = f"%{value}%" # Adjust value for LIKE
+                else:
+                    # Default case for exact matches, ensure key is a valid column name
+                    # For safety, you might want to validate 'key' against a list of allowed column names
+                    # to prevent SQL injection if filter keys can come from untrusted sources.
+                    # However, based on current usage in ExperienceModuleWidget, keys are controlled.
+                    conditions.append(f"{key} = ?")
                 params.append(value)
         if conditions:
             query += " WHERE " + " AND ".join(conditions)

--- a/db/cruds/media_items_crud.py
+++ b/db/cruds/media_items_crud.py
@@ -1,0 +1,53 @@
+import sqlite3
+from db.connection import get_db_connection # Assuming this utility exists for DB connection
+import logging
+
+# Placeholder for media items CRUD operations.
+# This file is created to resolve an ImportError.
+# Actual media item functionality needs to be implemented.
+
+def get_all_media_items(filters: dict = None, conn: sqlite3.Connection = None, limit: int = None, offset: int = 0) -> list:
+    """
+    Placeholder function to fetch all media items.
+    Currently returns an empty list.
+    """
+    logger = logging.getLogger(__name__)
+    logger.info(f"media_items_crud.get_all_media_items called with filters: {filters}, limit: {limit}, offset: {offset}. (Placeholder - returning empty list)")
+
+    # Example of how it might eventually be implemented (partial, for illustration):
+    # db = conn if conn else get_db_connection()
+    # db.row_factory = sqlite3.Row
+    # cursor = db.cursor()
+    # query = "SELECT * FROM MediaItems"
+    # params = []
+    # # Add filter handling, limit, offset as in other CRUD modules
+    # try:
+    #     cursor.execute(query, params)
+    #     rows = cursor.fetchall()
+    #     return [dict(row) for row in rows]
+    # except sqlite3.Error as e:
+    #     logger.error(f"Error fetching media items (placeholder): {e}")
+    #     return []
+    # finally:
+    #     if not conn: # Only close if we opened the connection
+    #         db.close()
+
+    return []
+
+def get_media_item_by_id(media_item_id: str, conn: sqlite3.Connection = None) -> dict | None:
+    """
+    Placeholder function to fetch a single media item by its ID.
+    Currently returns None.
+    """
+    logger = logging.getLogger(__name__)
+    logger.info(f"media_items_crud.get_media_item_by_id called with ID: {media_item_id}. (Placeholder - returning None)")
+    return None
+
+# Add other placeholder CRUD functions as needed by the application if their absence causes errors.
+# For example, if add_media_item, update_media_item, delete_media_item are called elsewhere.
+# Based on experience_module_widget.py, get_all_media_items is the primary one needed for SelectMediaDialog.
+
+__all__ = [
+    "get_all_media_items",
+    "get_media_item_by_id"
+]

--- a/db/db_seed.py
+++ b/db/db_seed.py
@@ -300,7 +300,8 @@ def seed_initial_data(cursor: sqlite3.Cursor):
                 "language_code": "en",
                 "base_unit_price": 10.00,
                 "unit_of_measure": "unit",
-                "is_active": True
+                "is_active": True,
+                "product_code": "PROD001"
             },
             {
                 "product_name": "Industrial Widget",
@@ -309,7 +310,8 @@ def seed_initial_data(cursor: sqlite3.Cursor):
                 "language_code": "en",
                 "base_unit_price": 100.00,
                 "unit_of_measure": "piece",
-                "is_active": True
+                "is_active": True,
+                "product_code": "PROD002"
             },
             {
                 "product_name": "Gadget Standard",
@@ -318,7 +320,8 @@ def seed_initial_data(cursor: sqlite3.Cursor):
                 "language_code": "fr",
                 "base_unit_price": 50.00,
                 "unit_of_measure": "unité",
-                "is_active": True
+                "is_active": True,
+                "product_code": "PROD003"
             },
             {
                 "product_name": "Advanced Gizmo",
@@ -327,7 +330,8 @@ def seed_initial_data(cursor: sqlite3.Cursor):
                 "language_code": "en",
                 "base_unit_price": 250.00,
                 "unit_of_measure": "item",
-                "is_active": True
+                "is_active": True,
+                "product_code": "PROD004"
             }
         ]
 

--- a/icons.qrc
+++ b/icons.qrc
@@ -65,7 +65,9 @@
     <file alias="search.svg">icons/search.svg</file>
     <file alias="arrow-left-circle.svg">icons/arrow-left-circle.svg</file>
     <file alias="mic.svg">icons/mic.svg</file>
-    <file alias="edit.svg">icons/edit.svg</file>
+    <file alias="edit.svg">icons/edit-2.svg</file>
     <file alias="video.svg">icons/video.svg</file>
+    <file alias="refresh.svg">icons/refresh-cw.svg</file>
+    <file alias="settings-gear.svg">icons/settings.svg</file>
 </qresource>
 </RCC>


### PR DESCRIPTION
This commit resolves several issues identified from application logs:

1.  **Product Seeding `product_code`:**
    - Modified `db/db_seed.py` to include the mandatory `product_code` field for each sample product during database seeding. This fixes the "Missing required field: product_code" errors.

2.  **Experience Filtering `date_from`:**
    - Updated `db/cruds/experience_crud.py` to correctly filter experiences by date. The `get_all_experiences` function now maps `date_from` and `date_to` filter parameters to conditions on the `experience_date` database column (i.e., `experience_date >= ?` and `experience_date <= ?`), resolving the "no such column: date_from" SQL error.

3.  **Missing `media_items_crud` Module:**
    - Created a placeholder `db/cruds/media_items_crud.py` with an empty `get_all_media_items` function. This resolves the `ImportError` for this module in `experience_module_widget.py` and allows the application to run. Full media functionality will require further implementation in this module.

4.  **Missing SVG Icons:**
    - Updated `icons.qrc` to: - Change the alias for `edit.svg` to point to the existing `icons/edit-2.svg` file. - Add an alias for `refresh.svg` to point to `icons/refresh-cw.svg`. - Add an alias for `settings-gear.svg` to point to `icons/settings.svg`.
    - The icon `save.svg` could not be fixed as the file is missing from the `icons/` directory.
    - **Action Required:** The `icons_rc.py` file needs to be manually regenerated using a command like `pyrcc5 icons.qrc -o icons_rc.py` for these icon changes to take effect, as I was unable to perform this step.

5.  **PyAudio Warning:**
    - `PyAudio` is already correctly listed in `requirements.txt`. The warning indicates that the library is not installed in the runtime environment.

The GLib-GIO UWP warnings were not addressed as they are likely environment-specific.