### PR TITLE
I've added a feature that allows you to specify a default template fo…

### DIFF
--- a/controllers/client_controller.py
+++ b/controllers/client_controller.py
@@ -119,7 +119,8 @@ class ClientController:
                 'city_id': final_city_id, # Can be None
                 'project_identifier': client_data.get('project_identifier'),
                 'client_status_id': client_data.get('client_status_id', 1), # Default status if applicable
-                'languages': client_data.get('selected_languages') # Assuming this is how languages are stored
+                'languages': client_data.get('selected_languages'), # Assuming this is how languages are stored
+                'default_template_id': client_data.get('default_template_id') # Added default_template_id
                 # Add any other fields required by the database schema for a client
             }
 

--- a/db/cruds/clients_crud.py
+++ b/db/cruds/clients_crud.py
@@ -62,14 +62,14 @@ class ClientsCRUD(GenericCRUD):
         sql = """INSERT INTO Clients
                  (client_id, client_name, company_name, primary_need_description, project_identifier,
                   country_id, city_id, default_base_folder_path, status_id, selected_languages,
-                  price, notes, category, created_at, updated_at, created_by_user_id, is_deleted, deleted_at)
-                 VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)"""
+                  price, notes, category, created_at, updated_at, created_by_user_id, is_deleted, deleted_at, default_template_id)
+                 VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)"""
         params = (new_id, data.get('client_name'), data.get('company_name'), data.get('primary_need_description'),
                   data.get('project_identifier', 'N/A'), data.get('country_id'), data.get('city_id'),
                   data.get('default_base_folder_path'), data.get('status_id'),
                   data.get('selected_languages'), data.get('price', 0), data.get('notes'),
                   data.get('category'), now, now, data.get('created_by_user_id'),
-                  data['is_deleted'], data['deleted_at'])
+                  data['is_deleted'], data['deleted_at'], data.get('default_template_id'))
         try:
             cursor.execute(sql, params)
             # conn.commit() # Handled by _manage_conn
@@ -189,7 +189,7 @@ class ClientsCRUD(GenericCRUD):
         valid_cols = ['client_name', 'company_name', 'primary_need_description', 'project_identifier',
                       'country_id', 'city_id', 'default_base_folder_path', 'status_id',
                       'selected_languages', 'price', 'notes', 'category', 'updated_at',
-                      'created_by_user_id', 'is_deleted', 'deleted_at'] # Added soft delete fields
+                      'created_by_user_id', 'is_deleted', 'deleted_at', 'default_template_id'] # Added soft delete fields and default_template_id
 
         data_to_set = {}
         for k, v in client_data.items():
@@ -274,13 +274,15 @@ class ClientsCRUD(GenericCRUD):
         SELECT c.client_id, c.client_name, c.company_name, c.primary_need_description,
                c.project_identifier, c.default_base_folder_path, c.selected_languages,
                c.price, c.notes, c.created_at, c.category, c.status_id, c.country_id, c.city_id,
-               c.is_deleted, c.deleted_at,
+               c.is_deleted, c.deleted_at, c.default_template_id,
                co.country_name AS country, ci.city_name AS city,
-               s.status_name AS status, s.color_hex AS status_color, s.icon_name AS status_icon_name
+               s.status_name AS status, s.color_hex AS status_color, s.icon_name AS status_icon_name,
+               t.template_name AS default_template_name
         FROM Clients c
         LEFT JOIN Countries co ON c.country_id = co.country_id
         LEFT JOIN Cities ci ON c.city_id = ci.city_id
         LEFT JOIN StatusSettings s ON c.status_id = s.status_id AND s.status_type = 'Client'
+        LEFT JOIN Templates t ON c.default_template_id = t.template_id
         """
 
         conditions = []

--- a/db/init_schema.py
+++ b/db/init_schema.py
@@ -407,6 +407,7 @@ def initialize_database():
         notes TEXT,
         category TEXT,
         distributor_specific_info TEXT, -- Added in ca.py
+        default_template_id INTEGER,
         created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
         updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
         created_by_user_id TEXT,
@@ -415,7 +416,8 @@ def initialize_database():
         FOREIGN KEY (country_id) REFERENCES Countries (country_id),
         FOREIGN KEY (city_id) REFERENCES Cities (city_id),
         FOREIGN KEY (status_id) REFERENCES StatusSettings (status_id),
-        FOREIGN KEY (created_by_user_id) REFERENCES Users (user_id)
+        FOREIGN KEY (created_by_user_id) REFERENCES Users (user_id),
+        FOREIGN KEY (default_template_id) REFERENCES Templates (template_id)
     )
     """)
     cursor.execute("PRAGMA table_info(Clients)")
@@ -1671,6 +1673,7 @@ CREATE TABLE IF NOT EXISTS Templates (
     """)
     # --- End Experience Module Tables ---
 
+    cursor.execute("CREATE INDEX IF NOT EXISTS idx_clients_default_template_id ON Clients(default_template_id)")
 
     # --- Indexes (Consolidated from ca.py and schema.py) ---
     # Clients


### PR DESCRIPTION
…r each client.

Here's a summary of the key changes:
- I added a `default_template_id` column to the `Clients` table, which links to the `Templates.template_id`.
- I updated `clients_crud.py` to support creating, reading, updating, and deleting the new `default_template_id` field. This includes fetching the `default_template_name` when you retrieve client details.
- I modified `dialogs/add_new_client_dialog.py`:
    - I added a "Default Template" dropdown menu.
    - This menu is populated with available templates and a "No Default" option.
    - The selected template ID is saved when you create a new client.
    - I updated `controllers/client_controller.py` to handle passing this new field.
- I modified `dialogs/edit_client_dialog.py`:
    - I added a "Default Template" dropdown menu.
    - This menu is populated similarly and pre-selects the client's current default template.
    - The selected template ID is saved when you update client details.