### PR TITLE
Fix: Resolve ModuleNotFoundError for app_config

### DIFF
--- a/db/db_seed.py
+++ b/db/db_seed.py
@@ -1,6 +1,5 @@
 import os
 import sys
-import importlib.util
 import sqlite3
 import uuid
 import hashlib
@@ -10,36 +9,6 @@ import logging
 
 # Assuming config.py is in the parent directory (root)
 from config import DATABASE_PATH, DEFAULT_ADMIN_USERNAME
-
-# Determine project root and app_config.py path
-APP_ROOT_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__), os.pardir))
-APP_CONFIG_PATH = os.path.join(APP_ROOT_DIR, "app_config.py")
-
-# Dynamically load app_config using importlib
-try:
-    spec = importlib.util.spec_from_file_location("app_config", APP_CONFIG_PATH)
-    if spec is None:
-        raise ImportError(f"Could not load spec for module app_config from {APP_CONFIG_PATH}")
-    app_config_module = importlib.util.module_from_spec(spec)
-    if spec.loader is None:
-        raise ImportError(f"Spec loader for app_config is None.")
-    spec.loader.exec_module(app_config_module)
-    CONFIG = app_config_module.CONFIG
-    # Optional: Add to sys.modules if other modules imported by db_seed might also need it directly
-    # sys.modules['app_config'] = app_config_module
-except FileNotFoundError:
-    logging.error(f"app_config.py not found at {APP_CONFIG_PATH}")
-    raise
-except ImportError as e:
-    logging.error(f"Error importing app_config dynamically: {e}")
-    raise
-except AttributeError:
-    logging.error(f"CONFIG variable not found in the loaded app_config_module from {APP_CONFIG_PATH}")
-    raise
-# Add the project root to sys.path to allow importing app_config
-APP_ROOT_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__), os.pardir))
-if APP_ROOT_DIR not in sys.path:
-    sys.path.insert(0, APP_ROOT_DIR)
 
 from app_config import CONFIG
 

--- a/main.py
+++ b/main.py
@@ -1,6 +1,12 @@
 # -*- coding: utf-8 -*-
 import sys
 import os
+
+# Determine project root and add to sys.path
+PROJECT_ROOT = os.path.dirname(os.path.abspath(__file__))
+if PROJECT_ROOT not in sys.path:
+    sys.path.insert(0, PROJECT_ROOT)
+
 import logging # For main.py's own logging needs, and for translator parts if setup_logging isn't called first
 import icons_rc # Import the compiled resource file
 


### PR DESCRIPTION
Centralizes sys.path modification in main.py to ensure the project root is added to the Python path before any project-specific modules are imported.

Modifications:
- In `main.py`:
  - Calculated the project root using `os.path.dirname(os.path.abspath(__file__))`.
  - Inserted this project root into `sys.path[0]` at the beginning of the script.
- In `db/db_seed.py`:
  - Removed its local `APP_ROOT_DIR` calculation and `sys.path` manipulation for the purpose of importing `app_config`.
  - It now relies on `sys.path` being correctly set by the entry point.

This resolves the `ModuleNotFoundError: No module named 'app_config'` that occurred when `db_seed.py` attempted to import `CONFIG` from `app_config.py`.