### PR TITLE
Fix: Use importlib to load app_config.py in db_seed

### DIFF
--- a/db/db_seed.py
+++ b/db/db_seed.py
@@ -11,37 +11,36 @@ import logging
 # Assuming config.py is in the parent directory (root)
 from config import DATABASE_PATH, DEFAULT_ADMIN_USERNAME
 
-# Determine project root and app_config.py path
-APP_ROOT_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__), os.pardir))
-APP_CONFIG_PATH = os.path.join(APP_ROOT_DIR, "app_config.py")
+# Explicitly load app_config.py using importlib
+APP_ROOT_DIR_SEED = os.path.abspath(os.path.join(os.path.dirname(__file__), os.pardir))
+APP_CONFIG_PY_PATH = os.path.join(APP_ROOT_DIR_SEED, "app_config.py")
 
-# Dynamically load app_config using importlib
+logging.info(f"Attempting to load app_config.py from: {APP_CONFIG_PY_PATH}") # Add logging
+
 try:
-    spec = importlib.util.spec_from_file_location("app_config", APP_CONFIG_PATH)
-    if spec is None:
-        raise ImportError(f"Could not load spec for module app_config from {APP_CONFIG_PATH}")
-    app_config_module = importlib.util.module_from_spec(spec)
-    if spec.loader is None:
-        raise ImportError(f"Spec loader for app_config is None.")
-    spec.loader.exec_module(app_config_module)
-    CONFIG = app_config_module.CONFIG
-    # Optional: Add to sys.modules if other modules imported by db_seed might also need it directly
-    # sys.modules['app_config'] = app_config_module
-except FileNotFoundError:
-    logging.error(f"app_config.py not found at {APP_CONFIG_PATH}")
-    raise
-except ImportError as e:
-    logging.error(f"Error importing app_config dynamically: {e}")
-    raise
-except AttributeError:
-    logging.error(f"CONFIG variable not found in the loaded app_config_module from {APP_CONFIG_PATH}")
-    raise
-# Add the project root to sys.path to allow importing app_config
-APP_ROOT_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__), os.pardir))
-if APP_ROOT_DIR not in sys.path:
-    sys.path.insert(0, APP_ROOT_DIR)
+    config_spec = importlib.util.spec_from_file_location("app_config_module", APP_CONFIG_PY_PATH)
+    if config_spec is None:
+        logging.error(f"Could not load spec for app_config.py from {APP_CONFIG_PY_PATH}. File might not exist or is not accessible.")
+        raise ImportError(f"Could not load spec for app_config.py from {APP_CONFIG_PY_PATH}")
 
-from app_config import CONFIG
+    app_config_module = importlib.util.module_from_spec(config_spec)
+    # Add module to sys.modules to allow it to be "imported" by other modules if necessary,
+    # though for CONFIG, direct assignment is used here.
+    sys.modules['app_config_module_loaded_by_db_seed'] = app_config_module
+
+    if config_spec.loader is None:
+        logging.error(f"Spec loader for app_config.py is None for path {APP_CONFIG_PY_PATH}.")
+        raise ImportError(f"Spec loader for app_config.py is None.")
+
+    config_spec.loader.exec_module(app_config_module)
+    CONFIG = app_config_module.CONFIG
+    logging.info(f"Successfully loaded CONFIG from app_config.py using importlib from {APP_CONFIG_PY_PATH}")
+except FileNotFoundError:
+    logging.error(f"FileNotFoundError: app_config.py not found at {APP_CONFIG_PY_PATH} during importlib load.")
+    raise
+except Exception as e:
+    logging.error(f"An unexpected error occurred while loading app_config.py with importlib: {e}", exc_info=True)
+    raise
 
 # Import necessary functions directly from their new CRUD module locations
 from db.cruds.generic_crud import get_db_connection

--- a/main.py
+++ b/main.py
@@ -1,6 +1,12 @@
 # -*- coding: utf-8 -*-
 import sys
 import os
+
+# Determine project root and add to sys.path
+PROJECT_ROOT = os.path.dirname(os.path.abspath(__file__))
+if PROJECT_ROOT not in sys.path:
+    sys.path.insert(0, PROJECT_ROOT)
+
 import logging # For main.py's own logging needs, and for translator parts if setup_logging isn't called first
 import icons_rc # Import the compiled resource file
 


### PR DESCRIPTION
Revises the import of `app_config.CONFIG` within `db/db_seed.py` to use `importlib.util` with an absolute file path. This is to ensure `app_config.py` is loaded directly, bypassing potential issues with `sys.path` that led to a persistent `ModuleNotFoundError`.

Changes:
- In `db/db_seed.py`:
  - Replaced `from app_config import CONFIG` with logic that:
    1. Calculates the absolute path to `app_config.py`.
    2. Uses `importlib.util.spec_from_file_location` to get a module spec.
    3. Executes the module and extracts the `CONFIG` object.
  - Added logging around this import process for better diagnostics.
- `main.py` continues to set the project root in `sys.path` for general good practice and other imports.

This approach aims to definitively resolve the module loading issue for `app_config.py`.