### PR TITLE
Fix: Ensure default_template_id column exists in Clients table before…

### DIFF
--- a/db/init_schema.py
+++ b/db/init_schema.py
@@ -450,6 +450,20 @@ def initialize_database():
         except sqlite3.Error as e_alter_deleted_at:
             print(f"Error adding 'deleted_at' column to Clients table: {e_alter_deleted_at}")
 
+    # Ensure default_template_id column exists
+    cursor.execute("PRAGMA table_info(Clients)")
+    clients_columns_info_for_template_check = cursor.fetchall() # Use a unique variable name
+    clients_column_names_for_template_check = [info['name'] for info in clients_columns_info_for_template_check]
+
+    if 'default_template_id' not in clients_column_names_for_template_check:
+        try:
+            cursor.execute("ALTER TABLE Clients ADD COLUMN default_template_id INTEGER")
+            print("Added 'default_template_id' column to Clients table.")
+            # The FOREIGN KEY constraint is defined in the CREATE TABLE statement and will apply
+            # to new tables or if enforced by PRAGMA foreign_keys=ON for existing tables (version dependent).
+            # For existing tables in older SQLite, this adds the column, and app logic relies on the schema's FK definition.
+        except sqlite3.Error as e_alter_default_template_id:
+            print(f"Error adding 'default_template_id' column to Clients table: {e_alter_default_template_id}")
 
     # Create ClientNotes table (base from ca.py)
     cursor.execute("""


### PR DESCRIPTION
… indexing

The database initialization script (`db/init_schema.py`) could fail with an `sqlite3.OperationalError: no such column: default_template_id` when attempting to create an index on `Clients.default_template_id`. This occurred if the script was run against an existing database where the `Clients` table was created before this column was added to its schema.

This commit fixes the issue by:
1. Adding a check to see if the `default_template_id` column exists in the `Clients` table.
2. If the column is missing, it is added using `ALTER TABLE Clients ADD COLUMN default_template_id INTEGER`. The `FOREIGN KEY` constraint is already part of the `CREATE TABLE IF NOT EXISTS Clients` statement and will apply to newly created tables or when `PRAGMA foreign_keys=ON`.

This ensures the column exists before the `CREATE INDEX` statement is executed, preventing the error. The order of table creation (`Templates` before `Clients`) was also verified to be correct for the foreign key relationship.